### PR TITLE
Add shared header and mobile tweaks

### DIFF
--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -1,0 +1,27 @@
+import { Link } from "react-router-dom";
+import { useAuth } from "../auth/AuthContext";
+import React from "react";
+
+interface HeaderProps { children?: React.ReactNode }
+
+export default function Header({ children }: HeaderProps) {
+  const { user, logout } = useAuth();
+  return (
+    <header className="flex items-center justify-between px-4 sm:px-6 py-4 bg-neutral-800/75 backdrop-blur-sm">
+      <Link to="/" className="text-2xl font-extrabold flex items-center">
+        <span className="text-red-500">V</span>
+        <span className="text-white">ault</span>
+      </Link>
+      <div className="flex items-center space-x-4">
+        {children}
+        <span className="text-gray-200">{user?.username}</span>
+        <button
+          onClick={logout}
+          className="px-4 py-2 bg-orange-500 hover:bg-orange-600 rounded-md text-white"
+        >
+          Logout
+        </button>
+      </div>
+    </header>
+  );
+}

--- a/frontend/src/pages/ChatPage.tsx
+++ b/frontend/src/pages/ChatPage.tsx
@@ -14,6 +14,7 @@ import {
 } from "../graphql/operations";
 import { useAuth } from "../auth/AuthContext";
 import { useSearchParams, useNavigate } from "react-router-dom";
+import Header from "../components/Header";
 import {
   Users,
   Clipboard,
@@ -33,7 +34,7 @@ interface Message {
 }
 
 export default function ChatPage() {
-  const { user, logout } = useAuth();
+  const { user } = useAuth();
   const [searchParams] = useSearchParams();
   const navigate = useNavigate();
 
@@ -149,27 +150,14 @@ export default function ChatPage() {
     <div className="flex flex-col h-screen bg-neutral-900 text-white">
 
       {/* Header */}
-      <header className="flex items-center justify-between px-6 py-4 bg-neutral-800/75">
-        <h1 className="text-2xl font-bold">
-          <span className="text-red-500">V</span>ault
-        </h1>
-        <div className="flex items-center space-x-4">
-          <span className="text-gray-200">{user?.username}</span>
-          <button
-            onClick={logout}
-            className="px-4 py-2 bg-orange-500 hover:bg-orange-600 rounded-md"
-          >
-            Logout
-          </button>
-        </div>
-      </header>
+      <Header />
 
       {/* Body */}
-      <div className="flex flex-1 overflow-hidden">
+      <div className="flex flex-1 overflow-hidden flex-col sm:flex-row">
 
         {/* Friends Panel */}
         {panelOpen && (
-          <aside className="w-80 bg-neutral-800/75 p-4 flex-shrink-0 flex flex-col backdrop-blur-sm">
+          <aside className="w-full sm:w-80 bg-neutral-800/75 p-4 flex-shrink-0 flex flex-col backdrop-blur-sm">
             <div className="flex items-center justify-between mb-4">
               <h2 className="text-xl font-semibold">Friends</h2>
               <button onClick={() => setPanelOpen(false)} className="p-1">

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -1,8 +1,8 @@
 // src/pages/DashboardPage.tsx
 
 import { useEffect } from "react";
-import { useAuth } from "../auth/AuthContext";
-import { useNavigate, Link } from "react-router-dom";
+import { Link } from "react-router-dom";
+import Header from "../components/Header";
 import { HardDrive, GitBranch, MessageCircle, Settings } from "lucide-react";
 
 export default function DashboardPage() {
@@ -11,39 +11,11 @@ export default function DashboardPage() {
     document.title = "Dashboard";
   }, []);
 
-  const { user, logout } = useAuth();
-  const navigate = useNavigate();
-
-  // Handle logout: clear token and send back to home
-  const handleLogout = () => {
-    logout();
-    navigate("/", { replace: true });
-  };
 
   return (
     <div className="flex flex-col h-screen bg-neutral-900">
       {/* Header */}
-      <header className="flex items-center justify-between px-6 py-4 bg-neutral-800/75 backdrop-blur-sm">
-        {/* Logo */}
-        <div className="text-2xl font-extrabold">
-          <Link to="/" className="flex items-center">
-            <span className="text-red-500">V</span>
-            <span className="text-white">ault</span>
-          </Link>
-        </div>
-
-        {/* User info and logout */}
-        <div className="flex items-center space-x-4">
-          <span className="text-gray-200 font-medium">{user?.username}</span>
-          <button
-            onClick={handleLogout}
-            className="px-4 py-2 bg-orange-500 text-white rounded-md font-medium shadow
-                       hover:bg-red-600 active:bg-red-700 transition-colors duration-200"
-          >
-            Logout
-          </button>
-        </div>
-      </header>
+      <Header />
 
       {/* Main content: center four cards both vertically and horizontally */}
       <main className="flex-grow flex items-center justify-center p-6">

--- a/frontend/src/pages/MapPage.tsx
+++ b/frontend/src/pages/MapPage.tsx
@@ -54,7 +54,7 @@ import {
   MessageCircle,
 } from "lucide-react";
 import "reactflow/dist/style.css";
-import { useAuth } from "../auth/AuthContext";
+import Header from "../components/Header";
 import ChatBox from "../components/ChatBox"; // your reusable chat overlay
 
 interface FileOnNode {
@@ -91,7 +91,6 @@ interface QueryMyFilesResult {
 interface Friend { id: string; username: string }
 
 export default function MapPage() {
-  const { user, logout } = useAuth();
   const [sidebarCollapsed, setSidebarCollapsed] = useState(false);
 
   // chat overlay
@@ -494,30 +493,27 @@ export default function MapPage() {
   return (
     <div className="flex flex-col h-screen bg-neutral-900 text-white">
       {/* HEADER */}
-      <header className="flex items-center justify-between px-6 py-4 bg-neutral-800/75">
-        <div className="text-2xl font-extrabold">
-          <span className="text-red-500">V</span><span>ault</span>
-        </div>
-        <div className="flex items-center space-x-4">
-          <button onClick={handleAddNode} className="p-2 bg-orange-500 hover:bg-red-600 rounded">
-            <Plus size={16} className="text-white"/>
-          </button>
-          <button onClick={handleDeleteSelected} className="p-2 bg-orange-500 hover:bg-red-600 rounded">
-            <Minus size={16} className="text-white"/>
-          </button>
-          <span className="text-gray-200 font-medium">{user?.username}</span>
-          <button onClick={logout} className="px-4 py-2 bg-orange-500 hover:bg-red-600 rounded text-white">
-            Logout
-          </button>
-        </div>
-      </header>
+      <Header>
+        <button
+          onClick={handleAddNode}
+          className="p-2 bg-orange-500 hover:bg-red-600 rounded"
+        >
+          <Plus size={16} className="text-white" />
+        </button>
+        <button
+          onClick={handleDeleteSelected}
+          className="p-2 bg-orange-500 hover:bg-red-600 rounded"
+        >
+          <Minus size={16} className="text-white" />
+        </button>
+      </Header>
 
       {/* MAIN */}
-      <div className="flex flex-1">
+      <div className="flex flex-1 flex-col sm:flex-row">
         {/* SIDEBAR */}
         <aside
-          className={`flex flex-col transition-width duration-200 ease-in-out bg-neutral-800/75 p-2 ${
-            sidebarCollapsed ? "w-12" : "w-64"
+          className={`flex flex-col transition-all duration-200 bg-neutral-800/75 p-2 ${
+            sidebarCollapsed ? "w-12" : "w-full sm:w-64"
           } overflow-auto`}
           onDragOver={e=>e.preventDefault()}
           onDrop={handleSidebarDrop}

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -3,7 +3,7 @@
 import React, { useEffect } from "react";
 import { useQuery } from "@apollo/client";
 import { useNavigate } from "react-router-dom";
-import { useAuth } from "../auth/AuthContext";
+import Header from "../components/Header";
 import { QUERY_ME } from "../graphql/operations";
 
 interface MeResult {
@@ -25,7 +25,6 @@ export default function SettingsPage() {
   }, []);
 
   // 2) Auth & navigation
-  const { user, logout } = useAuth();
   const navigate = useNavigate();
 
   // 3) Fetch current user info
@@ -62,24 +61,7 @@ export default function SettingsPage() {
   return (
     <div className="flex flex-col h-screen bg-neutral-900 text-white">
       {/* Header */}
-      <header className="flex items-center justify-between px-6 py-4 bg-neutral-800/75 backdrop-blur-sm">
-        <div className="text-2xl font-extrabold">
-          <span className="text-red-500">V</span>
-          <span className="text-white">ault</span>
-        </div>
-        <div className="flex items-center space-x-4">
-          <span className="text-gray-200 font-medium">{username}</span>
-          <button
-            onClick={() => {
-              logout();
-              navigate("/login");
-            }}
-            className="px-4 py-2 bg-orange-500 text-white rounded-md font-medium hover:bg-red-600 transition-colors"
-          >
-            Logout
-          </button>
-        </div>
-      </header>
+      <Header />
 
       {/* Main content */}
       <main className="flex-1 overflow-y-auto p-6">

--- a/frontend/src/pages/StoragePage.tsx
+++ b/frontend/src/pages/StoragePage.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useState, type ChangeEvent } from "react";
 import { useQuery, useMutation, ApolloError, NetworkStatus } from "@apollo/client";
-import { useAuth } from "../auth/AuthContext";
+import Header from "../components/Header";
 import {
   QUERY_MY_FILES,
   MUTATION_UPLOAD_FILE,
@@ -44,7 +44,6 @@ export default function StoragePage() {
   }, []);
 
   // 2) AuthContext
-  const { user, logout } = useAuth();
 
   // 3) Fetch existing files
   const { data, loading, error, refetch, networkStatus } = useQuery<QueryMyFilesResult>(
@@ -148,21 +147,7 @@ export default function StoragePage() {
   return (
     <div className="flex flex-col h-screen bg-neutral-900 text-white">
       {/* Header */}
-      <header className="flex items-center justify-between px-6 py-4 bg-neutral-800/75 backdrop-blur-sm">
-        <div className="text-2xl font-extrabold">
-          <span className="text-red-500">V</span>
-          <span className="text-white">ault</span>
-        </div>
-        <div className="flex items-center space-x-4">
-          <span className="text-gray-200 font-medium">{user?.username}</span>
-          <button
-            onClick={logout}
-            className="px-4 py-2 bg-orange-500 text-white rounded-md font-medium shadow hover:bg-red-600 active:bg-red-700 transition-colors duration-200"
-          >
-            Logout
-          </button>
-        </div>
-      </header>
+      <Header />
 
       {/* Main content */}
       <main className="flex-grow p-6 overflow-auto">


### PR DESCRIPTION
## Summary
- add common `Header` component
- apply `Header` to dashboard, storage, map, chat and settings pages
- tweak map and chat layout for small screens

## Testing
- `npm run lint` *(fails: cannot find package '@eslint/js')*
- `python3 manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_684979f0313c832683cee0654215dd8c