### PR TITLE
Fix MapPage nodeFiles undefined

### DIFF
--- a/frontend/src/pages/MapPage.tsx
+++ b/frontend/src/pages/MapPage.tsx
@@ -539,7 +539,7 @@ export default function MapPage() {
             <div className="mb-2">
               <span className="text-gray-300 font-medium text-xs">Files</span>
               <ul className="space-y-1 mt-1 max-h-32 overflow-auto">
-                {nfData.nodeFiles.length > 0 ? (
+                {nfData?.nodeFiles?.length > 0 ? (
                   nfData.nodeFiles.map((nf:any)=>(
                     <li
                       key={nf.file.id}


### PR DESCRIPTION
## Summary
- guard against `nfData` being undefined when rendering files list

## Testing
- `python manage.py test`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68499d8be4cc83269dbe83595b999b8f