### PR TITLE
Update map node collapsed view and header link

### DIFF
--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -8,7 +8,7 @@ export default function Header({ children }: HeaderProps) {
   const { user, logout } = useAuth();
   return (
     <header className="flex items-center justify-between px-4 sm:px-6 py-4 bg-neutral-800/75 backdrop-blur-sm">
-      <Link to="/" className="text-2xl font-extrabold flex items-center">
+      <Link to="/dashboard" className="text-2xl font-extrabold flex items-center">
         <span className="text-red-500">V</span>
         <span className="text-white">ault</span>
       </Link>

--- a/frontend/src/pages/MapPage.tsx
+++ b/frontend/src/pages/MapPage.tsx
@@ -500,16 +500,22 @@ export default function MapPage() {
         <Handle type="source" position={Position.Right} style={handleStyle} />
 
         {/* Name */}
-        <div className="mb-3">
-          <label className="block text-gray-300 text-xs mb-1">Name</label>
-          <input
-            value={nm}
-            onChange={e=>setNm(e.target.value)}
-            onBlur={handleBlurOrEnter}
-            onKeyDown={e=>handleBlurOrEnter(e)}
-            className="w-full px-2 py-1 bg-neutral-700 text-white border border-neutral-600 rounded-md text-sm focus:outline-none focus:ring-2 focus:ring-orange-500"
-          />
-        </div>
+        {collapsed ? (
+          <div className="h-full flex items-center justify-center px-2">
+            <span className="text-white text-sm truncate">{data.name}</span>
+          </div>
+        ) : (
+          <div className="mb-3">
+            <label className="block text-gray-300 text-xs mb-1">Name</label>
+            <input
+              value={nm}
+              onChange={e=>setNm(e.target.value)}
+              onBlur={handleBlurOrEnter}
+              onKeyDown={e=>handleBlurOrEnter(e)}
+              className="w-full px-2 py-1 bg-neutral-700 text-white border border-neutral-600 rounded-md text-sm focus:outline-none focus:ring-2 focus:ring-orange-500"
+            />
+          </div>
+        )}
 
         {!collapsed && (
           <>


### PR DESCRIPTION
## Summary
- update CustomNode name display when collapsed
- fix header Vault logo to link to dashboard

## Testing
- `pip install -r backend/requirements.txt`
- `pytest -q`
- `npm run lint` *(fails: 8 errors, 9 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_6849a3a7f7848326bb6d69c2d23b1439