### PR TITLE
Disable GraphiQL websocket connection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+__pycache__/
+*.pyc
+frontend/node_modules/
+.env
+*.log

--- a/backend/vault/urls.py
+++ b/backend/vault/urls.py
@@ -9,6 +9,7 @@ from django.conf.urls.static import static
 from django.views.decorators.csrf import csrf_exempt
 # Use the special GraphQL view that handles multipart/file uploads
 from graphene_file_upload.django import FileUploadGraphQLView
+from .views import NoSubscriptionGraphQLView
 
 urlpatterns = [
     # Admin site
@@ -20,7 +21,7 @@ urlpatterns = [
     path(
         'graphql/',
         csrf_exempt(
-            FileUploadGraphQLView.as_view(graphiql=True)
+            NoSubscriptionGraphQLView.as_view(graphiql=True)
         ),
         name='graphql',
     ),

--- a/backend/vault/views.py
+++ b/backend/vault/views.py
@@ -1,0 +1,6 @@
+from graphene_file_upload.django import FileUploadGraphQLView
+
+class NoSubscriptionGraphQLView(FileUploadGraphQLView):
+    def __init__(self, *args, **kwargs):
+        kwargs.setdefault('subscription_path', '')
+        super().__init__(*args, **kwargs)


### PR DESCRIPTION
## Summary
- prevent GraphiQL from trying to open a WebSocket connection
- ignore temporary files via `.gitignore`

## Testing
- `PYTHONPATH=./backend DJANGO_SETTINGS_MODULE=vault.settings python backend/manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_6849d8c9ec14832693be446589ce5c21