### PR TITLE
Enable GraphQL subscriptions

### DIFF
--- a/backend/graph/apps.py
+++ b/backend/graph/apps.py
@@ -2,5 +2,9 @@ from django.apps import AppConfig
 
 
 class GraphConfig(AppConfig):
-    default_auto_field = 'django.db.models.BigAutoField'
-    name = 'graph'
+    default_auto_field = "django.db.models.BigAutoField"
+    name = "graph"
+
+    def ready(self):
+        # Import signal handlers to enable subscription broadcasts
+        from . import signals  # noqa: F401

--- a/backend/graph/signals.py
+++ b/backend/graph/signals.py
@@ -1,0 +1,12 @@
+from django.db.models.signals import post_save, post_delete
+from django.dispatch import receiver
+
+from .models import Node
+from vault.subscriptions import NodeUpdates
+
+
+@receiver(post_save, sender=Node)
+@receiver(post_delete, sender=Node)
+def broadcast_node_update(sender, instance, **kwargs):
+    # Notify subscribers whenever a Node is created, updated, or deleted
+    NodeUpdates.notify(instance.id)

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -7,3 +7,5 @@ graphene-django==3.2.3
 django-graphql-jwt>=0.4.0
 graphene-file-upload==1.3.0
 django-cors-headers>=3.13.0
+channels==4.2.2
+django-channels-graphql-ws==1.0.0rc7

--- a/backend/vault/asgi.py
+++ b/backend/vault/asgi.py
@@ -10,7 +10,25 @@ https://docs.djangoproject.com/en/5.2/howto/deployment/asgi/
 import os
 
 from django.core.asgi import get_asgi_application
+from channels.routing import ProtocolTypeRouter, URLRouter
+from channels.auth import AuthMiddlewareStack
+from django.urls import path
 
-os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'vault.settings')
+from .graphql import GraphqlWsConsumer
 
-application = get_asgi_application()
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "vault.settings")
+
+django_asgi_app = get_asgi_application()
+
+application = ProtocolTypeRouter(
+    {
+        "http": django_asgi_app,
+        "websocket": AuthMiddlewareStack(
+            URLRouter(
+                [
+                    path("graphql/", GraphqlWsConsumer.as_asgi()),
+                ]
+            )
+        ),
+    }
+)

--- a/backend/vault/graphql.py
+++ b/backend/vault/graphql.py
@@ -1,0 +1,24 @@
+from channels.db import database_sync_to_async
+from django.contrib.auth.models import AnonymousUser
+from graphql_jwt.utils import get_payload, get_user_by_payload
+import channels_graphql_ws
+
+from .schema import schema
+
+
+class GraphqlWsConsumer(channels_graphql_ws.GraphqlWsConsumer):
+    """WebSocket consumer handling GraphQL subscriptions."""
+
+    schema = schema
+
+    async def on_connect(self, payload):
+        token = payload.get("Authorization")
+        if token and token.startswith("JWT "):
+            try:
+                payload_data = get_payload(token[4:])
+                user = await database_sync_to_async(get_user_by_payload)(payload_data)
+                self.scope["user"] = user or AnonymousUser()
+            except Exception:  # invalid token
+                self.scope["user"] = AnonymousUser()
+        else:
+            self.scope["user"] = AnonymousUser()

--- a/backend/vault/schema.py
+++ b/backend/vault/schema.py
@@ -2,9 +2,11 @@
 
 import graphene, graphql_jwt
 from accounts.schema import AccountsQuery, AccountsMutation
-from files.schema    import FilesQuery, FilesMutation
-from graph.schema    import GraphQuery,  GraphMutation
-from chat.schema     import ChatQuery,   ChatMutation
+from files.schema import FilesQuery, FilesMutation
+from graph.schema import GraphQuery, GraphMutation
+from chat.schema import ChatQuery, ChatMutation
+from .subscriptions import NodeUpdates
+
 
 class Query(
     AccountsQuery,
@@ -12,7 +14,9 @@ class Query(
     GraphQuery,
     ChatQuery,
     graphene.ObjectType,
-): pass
+):
+    pass
+
 
 class Mutation(
     AccountsMutation,
@@ -21,8 +25,13 @@ class Mutation(
     ChatMutation,
     graphene.ObjectType,
 ):
-    tokenAuth   = graphql_jwt.ObtainJSONWebToken.Field()
+    tokenAuth = graphql_jwt.ObtainJSONWebToken.Field()
     verifyToken = graphql_jwt.Verify.Field()
-    refreshToken= graphql_jwt.Refresh.Field()
+    refreshToken = graphql_jwt.Refresh.Field()
 
-schema = graphene.Schema(query=Query, mutation=Mutation)
+
+class Subscription(graphene.ObjectType):
+    node_updates = NodeUpdates.Field()
+
+
+schema = graphene.Schema(query=Query, mutation=Mutation, subscription=Subscription)

--- a/backend/vault/settings.py
+++ b/backend/vault/settings.py
@@ -18,6 +18,7 @@ INSTALLED_APPS = [
     'django.contrib.sessions',
     'django.contrib.messages',
     'django.contrib.staticfiles',
+    'channels',
 
     # CORS support (must come before GraphQL apps so middleware order is correct)
     'corsheaders',
@@ -127,6 +128,13 @@ GRAPHENE = {
     'MIDDLEWARE': [
         'graphql_jwt.middleware.JSONWebTokenMiddleware',
     ],
+}
+
+# Channels layer configuration for WebSocket support
+CHANNEL_LAYERS = {
+    'default': {
+        'BACKEND': 'channels.layers.InMemoryChannelLayer',
+    }
 }
 
 # ─── DEFAULT PK FIELD TYPE ─────────────────────────────────────────

--- a/backend/vault/subscriptions.py
+++ b/backend/vault/subscriptions.py
@@ -1,0 +1,29 @@
+import graphene
+import channels_graphql_ws
+from asgiref.sync import async_to_sync
+
+
+class NodeUpdates(channels_graphql_ws.Subscription):
+    """Broadcast node update events."""
+
+    id = graphene.ID()
+    node_id = graphene.ID(required=False)
+
+    class Arguments:
+        node_id = graphene.ID(required=False)
+
+    @staticmethod
+    def subscribe(root, info, node_id=None):
+        group = f"node_{node_id}" if node_id else "nodes"
+        return [group]
+
+    @staticmethod
+    def publish(payload, info, node_id=None):
+        return NodeUpdates(id=payload.get("id"))
+
+    @classmethod
+    def notify(cls, node_id):
+        async_to_sync(cls.broadcast)(group="nodes", payload={"id": str(node_id)})
+        async_to_sync(cls.broadcast)(
+            group=f"node_{node_id}", payload={"id": str(node_id)}
+        )


### PR DESCRIPTION
## Summary
- add `channels` and `django-channels-graphql-ws` to backend requirements
- configure Channels in settings
- expose GraphQL WebSocket consumer in ASGI app
- implement `NodeUpdates` subscription and signal

## Testing
- `python backend/manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_6849ec210f708326b94cb9a942771ab7