### PR TITLE
Fix requirements conflict by downgrading Django

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,5 +1,5 @@
 asgiref==3.8.1
-Django==5.2.1
+Django==4.2.23
 mysqlclient==2.2.7
 sqlparse==0.5.3
 tzdata==2025.2


### PR DESCRIPTION
## Summary
- pin Django version to latest 4.2.x to satisfy `django-channels-graphql-ws` dependency

## Testing
- `pre-commit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849f4c626748326ace4bb0e4b2ddb22