### PR TITLE
Enable GraphQL WebSocket subscriptions

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -51,6 +51,8 @@ services:
     environment:
       # Point at your host’s Django API instead of the internal Docker hostname
       VITE_GRAPHQL_URL: ${VITE_GRAPHQL_URL:-http://localhost:8000/graphql/}
+      # WebSocket endpoint for GraphQL subscriptions
+      VITE_GRAPHQL_WS_URL: ${VITE_GRAPHQL_WS_URL:-ws://localhost:8000/graphql/}
       # Keep polling for file‑watching in Docker
       CHOKIDAR_USEPOLLING: "true"
     ports:

--- a/frontend/.env
+++ b/frontend/.env
@@ -1,1 +1,2 @@
 VITE_GRAPHQL_URL=http://${HOST_IP}:8000/graphql/
+VITE_GRAPHQL_WS_URL=ws://${HOST_IP}:8000/graphql/

--- a/start-vault.ps1
+++ b/start-vault.ps1
@@ -16,6 +16,7 @@ $envLines = @(
     "HOST_IP=${ip}"
     "CORS_ALLOWED_ORIGINS=http://${ip}:5173"
     "VITE_GRAPHQL_URL=http://${ip}:8000/graphql/"
+    "VITE_GRAPHQL_WS_URL=ws://${ip}:8000/graphql/"
 )
 $envLines | Set-Content -Path ".env" -Encoding UTF8
 
@@ -26,6 +27,8 @@ Write-Host "  http://${ip}:5173"
 Write-Host ""
 Write-Host "GraphQL endpoint:"
 Write-Host "  http://${ip}:8000/graphql/"
+Write-Host "GraphQL WebSocket endpoint:"
+Write-Host "  ws://${ip}:8000/graphql/"
 Write-Host ""
 
 # 4. Launch Docker Compose


### PR DESCRIPTION
## Summary
- pass VITE_GRAPHQL_WS_URL env variable to frontend containers
- include VITE_GRAPHQL_WS_URL in frontend .env example
- update start script to write VITE_GRAPHQL_WS_URL and show websocket endpoint

## Testing
- `python manage.py test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6849f954e40c832687759b4e48076ec5