### PR TITLE
Fix Django initialization order in ASGI app

### DIFF
--- a/backend/vault/asgi.py
+++ b/backend/vault/asgi.py
@@ -14,9 +14,9 @@ from channels.routing import ProtocolTypeRouter, URLRouter
 from channels.auth import AuthMiddlewareStack
 from django.urls import path
 
-from .graphql import GraphqlWsConsumer
-
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "vault.settings")
+
+from .graphql import GraphqlWsConsumer
 
 django_asgi_app = get_asgi_application()
 


### PR DESCRIPTION
## Summary
- set `DJANGO_SETTINGS_MODULE` before importing `GraphqlWsConsumer`

## Testing
- `pip install -r backend/requirements.txt`
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_684a0166fcd083268cd189276b944de3