### PR TITLE
Fix Django ASGI import order

### DIFF
--- a/backend/vault/asgi.py
+++ b/backend/vault/asgi.py
@@ -16,9 +16,9 @@ from django.urls import path
 
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "vault.settings")
 
-from .graphql import GraphqlWsConsumer
-
 django_asgi_app = get_asgi_application()
+
+from .graphql import GraphqlWsConsumer
 
 application = ProtocolTypeRouter(
     {


### PR DESCRIPTION
## Summary
- call `get_asgi_application()` before importing `GraphqlWsConsumer`

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_684a02e97950832681185eaee0dac9ed