### PR TITLE
Add chat message subscription

### DIFF
--- a/backend/chat/__init__.py
+++ b/backend/chat/__init__.py
@@ -1,0 +1,1 @@
+default_app_config = "chat.apps.ChatConfig"

--- a/backend/chat/apps.py
+++ b/backend/chat/apps.py
@@ -4,3 +4,7 @@ from django.apps import AppConfig
 class ChatConfig(AppConfig):
     default_auto_field = 'django.db.models.BigAutoField'
     name = 'chat'
+
+    def ready(self):
+        # Import signal handlers to enable subscription broadcasts
+        from . import signals  # noqa: F401

--- a/backend/chat/signals.py
+++ b/backend/chat/signals.py
@@ -1,0 +1,13 @@
+from django.db.models.signals import post_save, post_delete
+from django.dispatch import receiver
+
+from .models import Message
+from vault.subscriptions import MessageUpdates
+
+
+@receiver(post_save, sender=Message)
+@receiver(post_delete, sender=Message)
+def broadcast_message_update(sender, instance, **kwargs):
+    """Notify subscribers when a chat message is created or deleted."""
+    MessageUpdates.notify(instance.channel_id)
+

--- a/backend/vault/schema.py
+++ b/backend/vault/schema.py
@@ -5,7 +5,7 @@ from accounts.schema import AccountsQuery, AccountsMutation
 from files.schema import FilesQuery, FilesMutation
 from graph.schema import GraphQuery, GraphMutation
 from chat.schema import ChatQuery, ChatMutation
-from .subscriptions import NodeUpdates
+from .subscriptions import NodeUpdates, MessageUpdates
 
 
 class Query(
@@ -32,6 +32,7 @@ class Mutation(
 
 class Subscription(graphene.ObjectType):
     node_updates = NodeUpdates.Field()
+    message_updates = MessageUpdates.Field()
 
 
 schema = graphene.Schema(query=Query, mutation=Mutation, subscription=Subscription)

--- a/backend/vault/subscriptions.py
+++ b/backend/vault/subscriptions.py
@@ -27,3 +27,27 @@ class NodeUpdates(channels_graphql_ws.Subscription):
         async_to_sync(cls.broadcast)(
             group=f"node_{node_id}", payload={"id": str(node_id)}
         )
+
+
+class MessageUpdates(channels_graphql_ws.Subscription):
+    """Broadcast chat message events for a channel."""
+
+    channel_id = graphene.ID()
+
+    class Arguments:
+        channel_id = graphene.ID(required=True)
+
+    @staticmethod
+    def subscribe(root, info, channel_id):
+        return [f"channel_{channel_id}"]
+
+    @staticmethod
+    def publish(payload, info, channel_id):
+        return MessageUpdates(channel_id=payload.get("channel_id"))
+
+    @classmethod
+    def notify(cls, channel_id):
+        async_to_sync(cls.broadcast)(
+            group=f"channel_{channel_id}",
+            payload={"channel_id": str(channel_id)},
+        )

--- a/frontend/src/components/ChatBox.tsx
+++ b/frontend/src/components/ChatBox.tsx
@@ -3,7 +3,7 @@
 
 import React, { useEffect, useRef, useState } from "react";
 import { useQuery, useMutation, useSubscription } from "@apollo/client";
-import { QUERY_CHANNEL_MESSAGES, MUTATION_SEND_MESSAGE, SUBSCRIPTION_NODE_UPDATES } from "../graphql/operations";
+import { QUERY_CHANNEL_MESSAGES, MUTATION_SEND_MESSAGE, SUBSCRIPTION_MESSAGE_UPDATES } from "../graphql/operations";
 import { Send, X } from "lucide-react";
 import { useAuth } from "../auth/AuthContext";
 
@@ -36,7 +36,10 @@ export default function ChatBox({ channelId, onClose }: ChatBoxProps) {
   );
 
   // Subscribe to updates and refetch messages when an event arrives
-  const { data: subData } = useSubscription(SUBSCRIPTION_NODE_UPDATES);
+  const { data: subData } = useSubscription(SUBSCRIPTION_MESSAGE_UPDATES, {
+    variables: { channelId },
+    skip: !channelId,
+  });
   useEffect(() => {
     if (subData) refetch();
   }, [subData, refetch]);

--- a/frontend/src/graphql/operations.ts
+++ b/frontend/src/graphql/operations.ts
@@ -879,3 +879,11 @@ export const SUBSCRIPTION_NODE_UPDATES = gql`
     }
   }
 `;
+
+export const SUBSCRIPTION_MESSAGE_UPDATES = gql`
+  subscription MessageUpdates($channelId: ID!) {
+    messageUpdates(channelId: $channelId) {
+      channelId
+    }
+  }
+`;


### PR DESCRIPTION
## Summary
- add new MessageUpdates subscription to broadcast chat events
- wire message signals to trigger subscription
- expose subscription in GraphQL schema
- update ChatBox to use new subscription
- document new subscription operation

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_684a06e23f08832680311576efa4d0b8