### PR TITLE
Fix websockets on node drag

### DIFF
--- a/backend/graph/signals.py
+++ b/backend/graph/signals.py
@@ -1,7 +1,7 @@
 from django.db.models.signals import post_save, post_delete
 from django.dispatch import receiver
 
-from .models import Node
+from .models import Node, NodeFile, NodeShare, Edge
 from vault.subscriptions import NodeUpdates
 
 
@@ -10,3 +10,25 @@ from vault.subscriptions import NodeUpdates
 def broadcast_node_update(sender, instance, **kwargs):
     # Notify subscribers whenever a Node is created, updated, or deleted
     NodeUpdates.notify(instance.id)
+
+
+@receiver(post_save, sender=NodeFile)
+@receiver(post_delete, sender=NodeFile)
+def broadcast_nodefile_update(sender, instance, **kwargs):
+    """Notify subscribers when files are added to or removed from a node."""
+    NodeUpdates.notify(instance.node_id)
+
+
+@receiver(post_save, sender=NodeShare)
+@receiver(post_delete, sender=NodeShare)
+def broadcast_nodeshare_update(sender, instance, **kwargs):
+    """Notify subscribers when node shares change."""
+    NodeUpdates.notify(instance.node_id)
+
+
+@receiver(post_save, sender=Edge)
+@receiver(post_delete, sender=Edge)
+def broadcast_edge_update(sender, instance, **kwargs):
+    """Notify subscribers when edges are created or removed."""
+    NodeUpdates.notify(instance.node_a_id)
+    NodeUpdates.notify(instance.node_b_id)


### PR DESCRIPTION
## Summary
- broadcast node updates when NodeFile, NodeShare, and Edge models change

## Testing
- `python backend/manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_684a08e0e90483268b9af801e1910be0