### PR TITLE
Enable group and node chat channels

### DIFF
--- a/frontend/src/pages/MapPage.tsx
+++ b/frontend/src/pages/MapPage.tsx
@@ -490,7 +490,7 @@ export default function MapPage() {
         e: React.KeyboardEvent<HTMLElement> | React.FocusEvent<HTMLElement>,
         isArea = false
       ) => {
-      const k = (e as any).key;
+      const k = 'key' in e ? (e as React.KeyboardEvent<HTMLElement>).key : undefined;
       if (!isArea && k && k!=="Enter") return;
       if (nm!==data.name||desc!==data.description) commitRename(id,nm,desc);
     };


### PR DESCRIPTION
## Summary
- add group and node queries and mutations in `ChatPage`
- support selecting groups or nodes to open chats
- keep call panel behaviour the same
- fix lint issue in `MapPage`

## Testing
- `npm run lint`
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_684a166118d483269f4f4928a2b40fd8