### PR TITLE
Improve copy feedback in chat groups

### DIFF
--- a/frontend/src/pages/ChatPage.tsx
+++ b/frontend/src/pages/ChatPage.tsx
@@ -383,7 +383,7 @@ export default function ChatPage() {
                               : "bg-orange-500 hover:bg-orange-600"}
                           `}
                         >
-                          {g.name}
+                          {copiedGroupId === g.id ? "Copied" : g.name}
                         </button>
                         <button
                           onClick={() => handleCopyGroup(g.inviteCode, g.id)}


### PR DESCRIPTION
## Summary
- tweak groups list UI to show `Copied` after copying an invite

## Testing
- `npm run lint`
- `python manage.py test` *(fails: Unknown MySQL server host 'db')*

------
https://chatgpt.com/codex/tasks/task_e_684a8adefdac8326952bd503dec13d95