### PR TITLE
Add group chat mutation hook

### DIFF
--- a/frontend/src/pages/ChatPage.tsx
+++ b/frontend/src/pages/ChatPage.tsx
@@ -452,7 +452,7 @@ export default function ChatPage() {
                         className="flex-1 px-3 py-2 bg-neutral-700 rounded-md text-sm"
                       />
                       <button
-                        onClick={handleCopyGroup}
+                        onClick={() => handleCopyGroup()}
                         className={`p-2 rounded ${copiedGroup ? "bg-red-600" : "bg-orange-500 hover:bg-orange-600"}`}
                       >
                         <Clipboard size={16} />

--- a/frontend/src/pages/MapPage.tsx
+++ b/frontend/src/pages/MapPage.tsx
@@ -43,6 +43,7 @@ import {
   MUTATION_REVOKE_NODE_SHARE,
   MUTATION_CREATE_DIRECT_CHANNEL,
   MUTATION_JOIN_NODE_CHANNEL,
+  MUTATION_JOIN_GROUP_CHANNEL,
   SUBSCRIPTION_NODE_UPDATES,
 } from "../graphql/operations";
 import {
@@ -115,6 +116,9 @@ export default function MapPage() {
   });
   const [joinNodeChannel] = useMutation(MUTATION_JOIN_NODE_CHANNEL, {
     onCompleted: res => setChatChannel(res.joinNodeChannel.channel.id),
+  });
+  const [joinGroupChannel] = useMutation(MUTATION_JOIN_GROUP_CHANNEL, {
+    onCompleted: res => setChatChannel(res.joinGroupChannel.channel.id),
   });
 
   // friends
@@ -923,6 +927,12 @@ export default function MapPage() {
                           className="p-1 bg-neutral-700 hover:bg-red-600 rounded"
                         >
                           <Share2 className="text-white" size={14}/>
+                        </button>
+                        <button
+                          onClick={()=>joinGroupChannel({ variables:{ groupId:g.id } })}
+                          className="p-1 bg-neutral-700 hover:bg-red-600 rounded"
+                        >
+                          <MessageCircle className="text-white" size={14}/>
                         </button>
                       </div>
                     </div>


### PR DESCRIPTION
## Summary
- import `MUTATION_JOIN_GROUP_CHANNEL` in `MapPage`
- create `joinGroupChannel` mutation hook to open chat overlay
- add chat button for each group in `MapPage`
- fix `ChatPage` copy button handler

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684a92877c2883269f317573c5c720b7