### PR TITLE
Fix sidebar chat icon duplication and limit node width

### DIFF
--- a/frontend/src/pages/MapPage.tsx
+++ b/frontend/src/pages/MapPage.tsx
@@ -569,7 +569,7 @@ export default function MapPage() {
       <div
         onDragOver={onDragOver}
         onDrop={onDrop}
-        className={`relative bg-neutral-800/75 rounded-xl p-2 select-none flex flex-col ${
+        className={`relative bg-neutral-800/75 rounded-xl p-2 select-none flex flex-col w-60 ${
           collapsed ? "" : "space-y-2"
         } ${selected ? "ring-2 ring-orange-500" : ""}`}
         style={{
@@ -932,12 +932,6 @@ export default function MapPage() {
                           className="p-1 bg-neutral-700 hover:bg-red-600 rounded"
                         >
                           <MessageCircle className="text-white" size={14} />
-                        </button>
-                        <button
-                          onClick={()=>joinGroupChannel({ variables:{ groupId:g.id } })}
-                          className="p-1 bg-neutral-700 hover:bg-red-600 rounded"
-                        >
-                          <MessageCircle className="text-white" size={14}/>
                         </button>
                       </div>
                     </div>


### PR DESCRIPTION
## Summary
- remove duplicate chat icon button from group list
- limit custom node size in map view

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684a954fa73c83268230e90a6f58da2f