### PR TITLE
Add UpdateProfile mutation

### DIFF
--- a/backend/accounts/schema.py
+++ b/backend/accounts/schema.py
@@ -281,6 +281,31 @@ class JoinGroupByInvite(graphene.Mutation):
         return JoinGroupByInvite(group=grp)
 
 
+class UpdateProfile(graphene.Mutation):
+    """Update the authenticated user's profile fields."""
+
+    profile = graphene.Field(ProfileType)
+
+    class Arguments:
+        avatar_url = graphene.String()
+        bio = graphene.String()
+        is_public = graphene.Boolean()
+
+    def mutate(self, info, avatar_url=None, bio=None, is_public=None):
+        user = info.context.user
+        if user.is_anonymous:
+            raise GraphQLError("Login required.")
+        profile = user.profile
+        if avatar_url is not None:
+            profile.avatar_url = avatar_url
+        if bio is not None:
+            profile.bio = bio
+        if is_public is not None:
+            profile.is_public = is_public
+        profile.save()
+        return UpdateProfile(profile=profile)
+
+
 class AccountsMutation(graphene.ObjectType):
     create_user          = CreateUser.Field()
     create_friend_invite = CreateFriendInvite.Field()
@@ -288,3 +313,4 @@ class AccountsMutation(graphene.ObjectType):
     revoke_friend_invite = RevokeFriendInvite.Field()
     create_group         = CreateGroup.Field()
     join_group_by_invite = JoinGroupByInvite.Field()
+    update_profile       = UpdateProfile.Field()

--- a/backend/accounts/tests.py
+++ b/backend/accounts/tests.py
@@ -18,3 +18,29 @@ class GroupInviteRotationTests(TestCase):
         grp.register_invite_use()
         self.assertEqual(grp.invite_uses_count, 0)
         self.assertNotEqual(grp.invite_code, first_code)
+
+
+class UpdateProfileTests(TestCase):
+    def setUp(self):
+        User = get_user_model()
+        self.user = User.objects.create_user(username="user", password="pw")
+
+    def _info(self):
+        from types import SimpleNamespace
+
+        return SimpleNamespace(context=SimpleNamespace(user=self.user))
+
+    def test_update_profile_fields(self):
+        from .schema import UpdateProfile
+
+        UpdateProfile().mutate(
+            self._info(),
+            avatar_url="http://example.com/avatar.png",
+            bio="Hello",
+            is_public=True,
+        )
+
+        self.user.profile.refresh_from_db()
+        self.assertEqual(self.user.profile.avatar_url, "http://example.com/avatar.png")
+        self.assertEqual(self.user.profile.bio, "Hello")
+        self.assertTrue(self.user.profile.is_public)


### PR DESCRIPTION
## Summary
- allow logged-in users to update their profile via new `UpdateProfile` mutation
- expose `update_profile` on `AccountsMutation`
- add unit test covering mutation logic

## Testing
- `pip install -r backend/requirements.txt`
- `cd backend && DJANGO_SETTINGS_MODULE=test_settings python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_684aa9184e448326a3b8b6d674bd5563