### PR TITLE
Use user icon placeholders

### DIFF
--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -1,6 +1,6 @@
 import { Link } from "react-router-dom";
 import { Menu } from "@headlessui/react";
-import { ChevronDown } from "lucide-react";
+import { ChevronDown, User } from "lucide-react";
 import { useAuth } from "../auth/AuthContext";
 import React from "react";
 
@@ -26,7 +26,7 @@ export default function Header({ children }: HeaderProps) {
               />
             ) : (
               <div className="h-8 w-8 rounded-full bg-neutral-700 flex items-center justify-center text-gray-300">
-                {user?.username?.charAt(0).toUpperCase()}
+                <User size={16} />
               </div>
             )}
             <span className="text-gray-200 hidden sm:block">{user?.username}</span>

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from "react";
 import { useQuery, useMutation, ApolloError } from "@apollo/client";
 import { useNavigate } from "react-router-dom";
 import Header from "../components/Header";
+import { User } from "lucide-react";
 import {
   QUERY_ME,
   MUTATION_UPLOAD_FILE,
@@ -135,7 +136,7 @@ export default function SettingsPage() {
                   />
                 ) : (
                   <div className="h-16 w-16 rounded-full bg-neutral-700 flex items-center justify-center text-gray-400">
-                    N/A
+                    <User size={32} />
                   </div>
                 )}
                 <div>


### PR DESCRIPTION
## Summary
- show a lucide-react user icon when the avatar is missing in `Header`
- use the same user icon for the missing profile image in `SettingsPage`

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_684aafd341c4832682725213df8e2c24