### PR TITLE
Add account update and deletion features

### DIFF
--- a/frontend/src/graphql/operations.ts
+++ b/frontend/src/graphql/operations.ts
@@ -275,6 +275,28 @@ export const MUTATION_UPDATE_PROFILE = gql`
   }
 `;
 
+// 13) Update the authenticated user's account info
+export const MUTATION_UPDATE_USER = gql`
+  mutation UpdateUser($username: String, $email: String, $password: String) {
+    updateUser(username: $username, email: $email, password: $password) {
+      user {
+        id
+        username
+        email
+      }
+    }
+  }
+`;
+
+// 14) Delete the current user's account
+export const MUTATION_DELETE_ACCOUNT = gql`
+  mutation DeleteAccount {
+    deleteAccount {
+      ok
+    }
+  }
+`;
+
 /* ──────────────────────────────────────────────────────────────────────────────
    FILES (UPLOADS / VERSIONS / SHARES)
    ────────────────────────────────────────────────────────────────────────────── */


### PR DESCRIPTION
## Summary
- add `UpdateUser` and `DeleteAccount` mutations to backend
- expose these in GraphQL schema
- provide frontend GraphQL operations
- update Settings page with account update and delete forms

## Testing
- `pip install -r backend/requirements.txt`
- `DJANGO_SETTINGS_MODULE=test_settings python manage.py test accounts.tests`

------
https://chatgpt.com/codex/tasks/task_e_684ab0cdb18c8326ab6fe43efba87b0c