### PR TITLE
Remove profile visibility setting

### DIFF
--- a/backend/accounts/migrations/0006_remove_profile_is_public.py
+++ b/backend/accounts/migrations/0006_remove_profile_is_public.py
@@ -1,0 +1,13 @@
+from django.db import migrations
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("accounts", "0005_profile_avatar_file"),
+    ]
+
+    operations = [
+        migrations.RemoveField(
+            model_name="profile",
+            name="is_public",
+        ),
+    ]

--- a/backend/accounts/models.py
+++ b/backend/accounts/models.py
@@ -31,7 +31,6 @@ class Profile(models.Model):
     )
     avatar_url = models.URLField(blank=True)
     bio        = models.TextField(blank=True)
-    is_public  = models.BooleanField(default=False)
 
     def __str__(self):
         return f"Profile for {self.user.username}"

--- a/backend/accounts/schema.py
+++ b/backend/accounts/schema.py
@@ -20,7 +20,7 @@ class ProfileType(DjangoObjectType):
 
     class Meta:
         model = Profile
-        fields = ("avatar_url", "bio", "is_public")
+        fields = ("avatar_url", "bio")
 
     def resolve_avatar_url(self, info):
         if self.avatar_file:
@@ -298,9 +298,8 @@ class UpdateProfile(graphene.Mutation):
         avatar_url = graphene.String()
         avatar_file_id = graphene.ID()
         bio = graphene.String()
-        is_public = graphene.Boolean()
 
-    def mutate(self, info, avatar_url=None, avatar_file_id=None, bio=None, is_public=None):
+    def mutate(self, info, avatar_url=None, avatar_file_id=None, bio=None):
         user = info.context.user
         if user.is_anonymous:
             raise GraphQLError("Login required.")
@@ -316,8 +315,6 @@ class UpdateProfile(graphene.Mutation):
             profile.avatar_url = info.context.build_absolute_uri(file_obj.upload.url)
         if bio is not None:
             profile.bio = bio
-        if is_public is not None:
-            profile.is_public = is_public
         profile.save()
         return UpdateProfile(profile=profile)
 

--- a/backend/accounts/tests.py
+++ b/backend/accounts/tests.py
@@ -42,13 +42,11 @@ class UpdateProfileTests(TestCase):
             self._info(),
             avatar_url="http://example.com/avatar.png",
             bio="Hello",
-            is_public=True,
         )
 
         self.user.profile.refresh_from_db()
         self.assertEqual(self.user.profile.avatar_url, "http://example.com/avatar.png")
         self.assertEqual(self.user.profile.bio, "Hello")
-        self.assertTrue(self.user.profile.is_public)
 
     def test_update_profile_with_avatar_file(self):
         from .schema import UpdateProfile

--- a/frontend/src/auth/AuthContext.tsx
+++ b/frontend/src/auth/AuthContext.tsx
@@ -11,7 +11,6 @@ interface User {
   profile?: {
     avatarUrl?: string;
     bio?: string;
-    isPublic?: boolean;
   };
 }
 

--- a/frontend/src/graphql/operations.ts
+++ b/frontend/src/graphql/operations.ts
@@ -51,7 +51,6 @@ export const QUERY_ME = gql`
       profile {
         avatarUrl
         bio
-        isPublic
       }
     }
   }
@@ -94,7 +93,6 @@ export const QUERY_FRIENDS = gql`
       profile {
         avatarUrl
         bio
-        isPublic
       }
     }
   }
@@ -145,7 +143,6 @@ export const MUTATION_CREATE_USER = gql`
         profile {
           avatarUrl
           bio
-          isPublic
         }
       }
       token
@@ -258,18 +255,15 @@ export const MUTATION_UPDATE_PROFILE = gql`
     $avatarUrl: String
     $avatarFileId: ID
     $bio: String
-    $isPublic: Boolean
   ) {
     updateProfile(
       avatarUrl: $avatarUrl
       avatarFileId: $avatarFileId
       bio: $bio
-      isPublic: $isPublic
     ) {
       profile {
         avatarUrl
         bio
-        isPublic
       }
     }
   }

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -21,7 +21,6 @@ interface MeResult {
     profile: {
       avatarUrl: string | null;
       bio: string | null;
-      isPublic: boolean;
     };
   };
 }
@@ -41,7 +40,6 @@ export default function SettingsPage() {
   });
 
   const [bio, setBio] = useState("");
-  const [isPublic, setIsPublic] = useState(false);
   const [avatarFile, setAvatarFile] = useState<File | null>(null);
   const [newUsername, setNewUsername] = useState<string>("");
   const [newEmail, setNewEmail] = useState<string>("");
@@ -94,7 +92,6 @@ export default function SettingsPage() {
   useEffect(() => {
     if (profile) {
       setBio(profile.bio || "");
-      setIsPublic(profile.isPublic);
     }
   }, [profile]);
 
@@ -137,7 +134,7 @@ export default function SettingsPage() {
     }
     try {
       await updateProfile({
-        variables: { avatarFileId, bio, isPublic },
+        variables: { avatarFileId, bio },
       });
     } catch {
       // onError handles message
@@ -223,12 +220,6 @@ export default function SettingsPage() {
                 </p>
               </div>
 
-              <div>
-                <p className="text-gray-300 font-medium mb-1">Profile Visibility:</p>
-                <p className="text-gray-200">
-                  {profile?.isPublic ? "Public" : "Private"}
-                </p>
-              </div>
             </div>
 
             {successMsg && (
@@ -258,18 +249,6 @@ export default function SettingsPage() {
                 />
               </div>
 
-              <div className="flex items-center space-x-2">
-                <input
-                  id="isPublic"
-                  type="checkbox"
-                  checked={isPublic}
-                  onChange={(e) => setIsPublic(e.target.checked)}
-                  className="h-5 w-5 text-orange-500"
-                />
-                <label htmlFor="isPublic" className="text-gray-300">
-                  Profile is public
-                </label>
-              </div>
 
               <button
                 type="submit"


### PR DESCRIPTION
## Summary
- drop `is_public` from Profile model
- migrate database to remove that field
- adjust schema and tests for profile updates
- remove visibility option from React settings page
- update GraphQL operations and auth context

## Testing
- `pip install -r requirements.txt`
- `python manage.py test` *(fails: Unknown MySQL server host 'db')*

------
https://chatgpt.com/codex/tasks/task_e_684ab30753dc83269e97a556db6c9aec