### PR TITLE
Update profile UI and avatar behavior

### DIFF
--- a/backend/accounts/tests.py
+++ b/backend/accounts/tests.py
@@ -41,12 +41,13 @@ class UpdateProfileTests(TestCase):
         UpdateProfile().mutate(
             self._info(),
             avatar_url="http://example.com/avatar.png",
-            bio="Hello",
         )
 
         self.user.profile.refresh_from_db()
-        self.assertEqual(self.user.profile.avatar_url, "http://example.com/avatar.png")
-        self.assertEqual(self.user.profile.bio, "Hello")
+        self.assertEqual(
+            self.user.profile.avatar_url,
+            "http://example.com/avatar.png",
+        )
 
     def test_update_profile_with_avatar_file(self):
         from .schema import UpdateProfile

--- a/frontend/src/auth/AuthContext.tsx
+++ b/frontend/src/auth/AuthContext.tsx
@@ -10,7 +10,6 @@ interface User {
   email: string;
   profile?: {
     avatarUrl?: string;
-    bio?: string;
   };
 }
 

--- a/frontend/src/graphql/operations.ts
+++ b/frontend/src/graphql/operations.ts
@@ -50,7 +50,6 @@ export const QUERY_ME = gql`
       email
       profile {
         avatarUrl
-        bio
       }
     }
   }
@@ -92,7 +91,6 @@ export const QUERY_FRIENDS = gql`
       email
       profile {
         avatarUrl
-        bio
       }
     }
   }
@@ -142,7 +140,6 @@ export const MUTATION_CREATE_USER = gql`
         email
         profile {
           avatarUrl
-          bio
         }
       }
       token
@@ -251,19 +248,10 @@ export const MUTATION_JOIN_GROUP_BY_INVITE = gql`
 
 // 12) Update the authenticated user's profile
 export const MUTATION_UPDATE_PROFILE = gql`
-  mutation UpdateProfile(
-    $avatarUrl: String
-    $avatarFileId: ID
-    $bio: String
-  ) {
-    updateProfile(
-      avatarUrl: $avatarUrl
-      avatarFileId: $avatarFileId
-      bio: $bio
-    ) {
+  mutation UpdateProfile($avatarUrl: String, $avatarFileId: ID) {
+    updateProfile(avatarUrl: $avatarUrl, avatarFileId: $avatarFileId) {
       profile {
         avatarUrl
-        bio
       }
     }
   }


### PR DESCRIPTION
## Summary
- tweak user context interface
- remove `bio` usage and switch avatar upload to click-to-change UI
- drop `bio` from GraphQL queries and mutations
- adjust profile tests

## Testing
- `pip install -r requirements.txt`
- `python manage.py test` *(fails: Unknown MySQL server host 'db')*

------
https://chatgpt.com/codex/tasks/task_e_684ab6b819c88326830761eef7ef9019