### PR TITLE
Handle auth initialization state

### DIFF
--- a/frontend/src/auth/ProtectedRoute.tsx
+++ b/frontend/src/auth/ProtectedRoute.tsx
@@ -21,7 +21,7 @@ export default function ProtectedRoute({ children }: Props) {
   }
 
   // If not authenticated, redirect to "/" instead of "/login"
-  if (!isAuthenticated) {
+  if (!loading && !isAuthenticated) {
     return <Navigate to="/" state={{ from: location }} replace />;
   }
 


### PR DESCRIPTION
## Summary
- set `initializing` flag in `AuthContext` to cover initial token check
- mark auth loading true while checking token/user
- adjust redirect logic in `ProtectedRoute`

## Testing
- `npm run lint` *(fails: X is defined but never used, etc.)*
- `npm run build` *(fails: TS6133 'X' is declared but its value is never read, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_684ac0ff15ec832695a8036f5afecab9