### PR TITLE
Add theme color meta tags

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -3,6 +3,8 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="theme-color" content="#000000" />
+    <meta name="color-scheme" content="dark light" />
     <title>Vault</title>
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <script type="module" src="/src/main.tsx"></script>


### PR DESCRIPTION
## Summary
- indicate theme color and color scheme for the frontend

## Testing
- `npm --prefix frontend run lint` *(fails: Cannot find package '@eslint/js')*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_684ac25c9f3883268c91ea38b17643dc