### PR TITLE
Improve chat names and dark mode meta

### DIFF
--- a/backend/templates/index.html
+++ b/backend/templates/index.html
@@ -3,6 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="color-scheme" content="dark" />
     <title>Vault</title>
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <script type="module" crossorigin src="/assets/index-DF0a8CK-.js"></script>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -3,6 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="color-scheme" content="dark" />
     <title>Vault</title>
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <script type="module" src="/src/main.tsx"></script>

--- a/frontend/src/components/ChatBox.tsx
+++ b/frontend/src/components/ChatBox.tsx
@@ -23,9 +23,10 @@ interface Message {
 interface ChatBoxProps {
   channelId: string;
   onClose: () => void;
+  title?: string;
 }
 
-export default function ChatBox({ channelId, onClose }: ChatBoxProps) {
+export default function ChatBox({ channelId, onClose, title }: ChatBoxProps) {
   const { user } = useAuth();
   const userId = user?.id;
 
@@ -138,7 +139,9 @@ export default function ChatBox({ channelId, onClose }: ChatBoxProps) {
     <div className="fixed bottom-4 right-4 w-80 bg-neutral-800/90 rounded-lg shadow-lg flex flex-col">
       {/* Header */}
       <div className="flex justify-between items-center p-2 border-b border-neutral-700">
-        <h4 className="text-white text-sm">Chat</h4>
+        <h4 className="text-white text-sm">
+          {title || data?.channelMessages[0]?.channel.name || "Chat"}
+        </h4>
         <button onClick={onClose} className="p-1 hover:bg-neutral-700 rounded">
           <X className="text-white" size={16} />
         </button>

--- a/frontend/src/pages/MapPage.tsx
+++ b/frontend/src/pages/MapPage.tsx
@@ -109,15 +109,27 @@ export default function MapPage() {
   }, []);
 
   // chat overlay
-  const [chatChannel, setChatChannel] = useState<string | null>(null);
+  const [chatInfo, setChatInfo] = useState<{ id: string; name: string } | null>(null);
   const [createDirectChannel] = useMutation(MUTATION_CREATE_DIRECT_CHANNEL, {
-    onCompleted: res => setChatChannel(res.createDirectChannel.channel.id),
+    onCompleted: res =>
+      setChatInfo({
+        id: res.createDirectChannel.channel.id,
+        name: res.createDirectChannel.channel.name,
+      }),
   });
   const [joinNodeChannel] = useMutation(MUTATION_JOIN_NODE_CHANNEL, {
-    onCompleted: res => setChatChannel(res.joinNodeChannel.channel.id),
+    onCompleted: res =>
+      setChatInfo({
+        id: res.joinNodeChannel.channel.id,
+        name: res.joinNodeChannel.channel.name,
+      }),
   });
   const [joinGroupChannel] = useMutation(MUTATION_JOIN_GROUP_CHANNEL, {
-    onCompleted: res => setChatChannel(res.joinGroupChannel.channel.id),
+    onCompleted: res =>
+      setChatInfo({
+        id: res.joinGroupChannel.channel.id,
+        name: res.joinGroupChannel.channel.name,
+      }),
   });
 
   // friends
@@ -982,10 +994,11 @@ export default function MapPage() {
       </div>
 
       {/* Chat overlay */}
-      {chatChannel && (
+      {chatInfo && (
         <ChatBox
-          channelId={chatChannel}
-          onClose={() => setChatChannel(null)}
+          channelId={chatInfo.id}
+          title={chatInfo.name}
+          onClose={() => setChatInfo(null)}
         />
       )}
 


### PR DESCRIPTION
## Summary
- show channel titles in mini chat box via new `title` prop
- provide correct chat info when opening from Map page
- let browsers know the site is dark themed

## Testing
- `npx tsc --noEmit`
- `python manage.py test` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_684ac545294483268bd96ae493ea6609