### PR TITLE
Fix JSX closing tag in MapPage

### DIFF
--- a/frontend/src/pages/MapPage.tsx
+++ b/frontend/src/pages/MapPage.tsx
@@ -898,6 +898,7 @@ export default function MapPage() {
                           <MessageCircle className="text-white" size={14}/>
                         </button>
                     </div>
+                    </div>
                   );
                 })
               ) : (


### PR DESCRIPTION
## Summary
- fix missing closing tag on friend item div in MapPage

## Testing
- `npm run build` *(fails: Property 'channel' does not exist on type 'Message')*

------
https://chatgpt.com/codex/tasks/task_e_684acaec4ddc8326bcf97ad05893a01e