### PR TITLE
Switch JWT flow back to Authorization headers

### DIFF
--- a/backend/vault/settings.py
+++ b/backend/vault/settings.py
@@ -136,7 +136,8 @@ GRAPHQL_JWT = {
     'JWT_VERIFY_EXPIRATION': True,
     'JWT_COOKIE_NAME': 'access_token',
     'JWT_REFRESH_TOKEN_COOKIE_NAME': 'refresh_token',
-    'JWT_COOKIE_SECURE': False,  # set to True in production
+    'JWT_COOKIE_SECURE': True,
+    'JWT_COOKIE_HTTPONLY': True,
     'JWT_COOKIE_SAMESITE': 'Lax',
 }
 

--- a/backend/vault/urls.py
+++ b/backend/vault/urls.py
@@ -8,25 +8,17 @@ from django.conf.urls.static import static
 
 from django.views.generic import TemplateView
 
-from django.views.decorators.csrf import csrf_exempt
 # Use the special GraphQL view that handles multipart/file uploads
 from graphene_file_upload.django import FileUploadGraphQLView
-from graphql_jwt.decorators import jwt_cookie
 
 urlpatterns = [
     # Admin site
     path('admin/', admin.site.urls),
 
-    # GraphQL endpoint (with GraphiQL UI and file‐upload support)
-    # We wrap it in csrf_exempt so Altair/Electron (origin "electron://altair")
-    # won’t be blocked by Django’s CSRF middleware.
+    # GraphQL endpoint (with GraphiQL UI and file-upload support)
     path(
         'graphql/',
-        csrf_exempt(
-            jwt_cookie(
-                FileUploadGraphQLView.as_view(graphiql=True)
-            )
-        ),
+        FileUploadGraphQLView.as_view(graphiql=True),
         name='graphql',
     ),
 ]

--- a/frontend/src/apolloClient.ts
+++ b/frontend/src/apolloClient.ts
@@ -3,6 +3,7 @@
 import { ApolloClient, InMemoryCache, split } from "@apollo/client";
 // Default import from the ESM file
 import createUploadLink from "apollo-upload-client/createUploadLink.mjs";
+import { setContext } from "@apollo/client/link/context";
 import { GraphQLWsLink } from "@apollo/client/link/subscriptions";
 import { getMainDefinition } from "@apollo/client/utilities";
 import { createClient } from "graphql-ws";
@@ -10,7 +11,6 @@ import { createClient } from "graphql-ws";
 // 1) Use createUploadLink so that file uploads (Upload scalars) are sent as multipart/form-data
 const httpLink = createUploadLink({
   uri: import.meta.env.VITE_GRAPHQL_URL || "http://localhost:8000/graphql/",
-  credentials: "include",
 });
 
 // Optional WebSocket link for subscriptions. If `VITE_GRAPHQL_WS_URL` is not
@@ -20,9 +20,24 @@ const wsLink = wsUrl
   ? new GraphQLWsLink(
       createClient({
         url: wsUrl,
+        connectionParams: () => {
+          const token = localStorage.getItem("token");
+          return token ? { Authorization: `JWT ${token}` } : {};
+        },
       })
     )
   : null;
+
+// 2) Attach JWT on every request
+const authLink = setContext((_, { headers }) => {
+  const token = localStorage.getItem("token");
+  return {
+    headers: {
+      ...headers,
+      authorization: token ? `JWT ${token}` : "",
+    },
+  };
+});
 
 let link = httpLink;
 
@@ -40,9 +55,9 @@ if (wsLink) {
   );
 }
 
-// 2) Create the Apollo Client with the chosen link
+// 4) Combine authLink with the chosen link into the Apollo Client
 const client = new ApolloClient({
-  link,
+  link: authLink.concat(link),
   cache: new InMemoryCache(),
 });
 

--- a/frontend/src/auth/AuthContext.tsx
+++ b/frontend/src/auth/AuthContext.tsx
@@ -17,7 +17,7 @@ interface AuthContextType {
   user: User | null;
   loading: boolean;
   isAuthenticated: boolean;
-  login: () => void;
+  login: (token: string) => void;
   logout: () => void;
 }
 
@@ -27,14 +27,17 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   const [user, setUser] = useState<User | null>(null);
   const [isAuthenticated, setIsAuthenticated] = useState(false);
 
-  // Use QUERY_ME to fetch current user based on the cookie
+  // Use QUERY_ME to fetch current user whenever there is a token
   const [loadMe, { data, loading, error }] = useLazyQuery<{ me: User }>(QUERY_ME, {
     fetchPolicy: "network-only",
   });
 
-  // On mount, check if a session already exists via cookie
+  // On mount, if a token exists, run the ME query
   useEffect(() => {
-    loadMe();
+    const token = localStorage.getItem("token");
+    if (token) {
+      loadMe();
+    }
   }, [loadMe]);
 
   // Update user / auth state when ME data arrives or errors out
@@ -43,17 +46,20 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       setUser(data.me);
       setIsAuthenticated(true);
     } else if (error) {
+      localStorage.removeItem("token");
       setUser(null);
       setIsAuthenticated(false);
     }
   }, [data, error]);
 
-  const login = () => {
+  const login = (token: string) => {
+    localStorage.setItem("token", token);
     setIsAuthenticated(true);
     loadMe();
   };
 
   const logout = () => {
+    localStorage.removeItem("token");
     setUser(null);
     setIsAuthenticated(false);
   };

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -30,8 +30,11 @@ export default function LoginPage() {
   }, [isAuthenticated, navigate, redirectTo]);
 
   const [tokenAuth, { loading }] = useMutation(MUTATION_TOKEN_AUTH, {
-    onCompleted() {
-      login();
+    onCompleted(data) {
+      const token = data.tokenAuth.token;
+      if (token) {
+        login(token);
+      }
     },
     onError(err) {
       setErrorMsg(err.message.replace("GraphQL error: ", ""));
@@ -64,6 +67,7 @@ export default function LoginPage() {
               value={username}
               onChange={(e) => setUsername(e.target.value)}
               className="w-full px-3 py-2 bg-neutral-700 text-white border border-neutral-600 rounded-md
+                         focus:outline-none focus:ring-2 focus:ring-red-500"
                          focus:outline-none focus:ring-2 focus:ring-red-500"
               required
             />

--- a/frontend/src/pages/SignupPage.tsx
+++ b/frontend/src/pages/SignupPage.tsx
@@ -16,13 +16,21 @@ export default function SignupPage() {
   const [password, setPassword] = useState("");
   const [errorMsg, setErrorMsg] = useState<string | null>(null);
 
-  const { login } = useAuth();
+  const { login, isAuthenticated } = useAuth();
   const navigate = useNavigate();
 
-  const [createUser, { loading }] = useMutation(MUTATION_CREATE_USER, {
-    onCompleted() {
-      login();
+  useEffect(() => {
+    if (isAuthenticated) {
       navigate("/dashboard", { replace: true });
+    }
+  }, [isAuthenticated, navigate]);
+
+  const [createUser, { loading }] = useMutation(MUTATION_CREATE_USER, {
+    onCompleted(data) {
+      const token = data.createUser.token;
+      if (token) {
+        login(token);
+      }
     },
     onError(err) {
       setErrorMsg(err.message.replace("GraphQL error: ", ""));


### PR DESCRIPTION
## Summary
- secure JWT cookies
- send GraphQL requests without csrf_exempt
- use Authorization header again in Apollo
- persist tokens in localStorage on login/signup

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684acfdeed288326a98e311b6858d0ca