### PR TITLE
Fix CSRF error for GraphQL endpoint

### DIFF
--- a/backend/vault/urls.py
+++ b/backend/vault/urls.py
@@ -10,6 +10,7 @@ from django.views.generic import TemplateView
 
 # Use the special GraphQL view that handles multipart/file uploads
 from graphene_file_upload.django import FileUploadGraphQLView
+from django.views.decorators.csrf import csrf_exempt
 
 urlpatterns = [
     # Admin site
@@ -18,7 +19,7 @@ urlpatterns = [
     # GraphQL endpoint (with GraphiQL UI and file-upload support)
     path(
         'graphql/',
-        FileUploadGraphQLView.as_view(graphiql=True),
+        csrf_exempt(FileUploadGraphQLView.as_view(graphiql=True)),
         name='graphql',
     ),
 ]


### PR DESCRIPTION
## Summary
- disable CSRF checks for `/graphql/` so JWT auth works properly

## Testing
- `python manage.py test --settings=test_settings`

------
https://chatgpt.com/codex/tasks/task_e_684ad54b639c8326baab50ac59c42c78