### PR TITLE
Default prod domain to LAN IP

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,7 +218,8 @@ Compose so the containers pick up the new settings.
 Use `start-vault-prod.ps1` when deploying to a real server. The script asks for
 your domain and secret values, writes the necessary `.env` files with
 `DEBUG=False` and proper `ALLOWED_HOSTS`, builds the frontend, then launches the
-stack.
+stack. If you don't provide a domain, the script will try to use your server's
+`192.168.x.x` LAN IP as the default.
 
 ```powershell
 ./start-vault-prod.ps1

--- a/start-vault-prod.ps1
+++ b/start-vault-prod.ps1
@@ -1,7 +1,28 @@
 # start-vault-prod.ps1
 # ────────────────────────────────────────────────────────────────────────
 # 1. Prompt for production domain and secrets
-$domain = Read-Host "Enter production domain (e.g. vault.example.com)"
+# Auto-detect a LAN IP (192.168.x.x) to use as the default domain
+$defaultDomain = $null
+try {
+    $defaultDomain = Get-NetIPAddress -AddressFamily IPv4 -ErrorAction Stop |
+                     Where-Object { $_.IPAddress -match '^192\.168\.' } |
+                     Select-Object -First 1 -ExpandProperty IPAddress
+} catch {
+    # Ignore errors on non-Windows systems
+}
+
+if (-not $defaultDomain) {
+    $defaultDomain = (hostname -I 2>$null) -split ' ' |
+                     Where-Object { $_ -match '^192\.168\.' } |
+                     Select-Object -First 1
+}
+
+if ($defaultDomain) {
+    $input = Read-Host "Enter production domain (e.g. vault.example.com) [$defaultDomain]"
+    $domain = if ($input) { $input } else { $defaultDomain }
+} else {
+    $domain = Read-Host "Enter production domain (e.g. vault.example.com)"
+}
 $djangoSecret = Read-Host "Enter DJANGO_SECRET_KEY"
 $jwtSecret = Read-Host "Enter GRAPHENE_JWT_SECRET"
 $mysqlPassword = Read-Host "MySQL password [s3cr3tpass]"


### PR DESCRIPTION
## Summary
- auto-detect LAN IP in `start-vault-prod.ps1` and use it as the default domain
- document this behavior in the README

## Testing
- `pip install -r backend/requirements.txt`
- `DJANGO_SETTINGS_MODULE=test_settings python manage.py test`
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684ae1e39864832692ae53a1f65421a7