### PR TITLE
Show error when media permission denied

### DIFF
--- a/frontend/src/components/ChatBox.tsx
+++ b/frontend/src/components/ChatBox.tsx
@@ -17,6 +17,7 @@ interface Message {
   id: string;
   sender: { id: string; username: string };
   text: string | null;
+  channel: { id: string; name: string };
   createdAt: string;
 }
 
@@ -46,6 +47,7 @@ export default function ChatBox({ channelId, onClose, title }: ChatBoxProps) {
     endCall,
     active,
     isVideo,
+    error: mediaError,
   } = useWebRTC((msg: SignalMessage) =>
     sendSignalMutation({ variables: { channelId, text: CALL_PREFIX + JSON.stringify(msg) } })
   );
@@ -223,6 +225,9 @@ export default function ChatBox({ channelId, onClose, title }: ChatBoxProps) {
           onEnd={endCall}
           video={isVideo}
         />
+      )}
+      {mediaError && (
+        <p className="text-red-400 text-center text-xs mt-2">{mediaError}</p>
       )}
     </div>
   );

--- a/frontend/src/hooks/useWebRTC.ts
+++ b/frontend/src/hooks/useWebRTC.ts
@@ -13,17 +13,21 @@ export default function useWebRTC(sendSignal: (msg: SignalMessage) => void) {
   const [localStream, setLocalStream] = useState<MediaStream | null>(null);
   const [remoteStream, setRemoteStream] = useState<MediaStream | null>(null);
   const [active, setActive] = useState(false);
+  const [error, setError] = useState<string | null>(null);
   const videoRef = useRef(false);
 
   async function getMedia(video: boolean): Promise<MediaStream | null> {
     if (!navigator.mediaDevices?.getUserMedia) {
       console.error("Media devices API unavailable");
+      setError("Media devices API unavailable");
       return null;
     }
     try {
+      setError(null);
       return await navigator.mediaDevices.getUserMedia({ audio: true, video });
     } catch (err) {
       console.error("Error accessing user media", err);
+      setError("Permission denied for camera/microphone");
       return null;
     }
   }
@@ -37,6 +41,7 @@ export default function useWebRTC(sendSignal: (msg: SignalMessage) => void) {
     setLocalStream(null);
     setRemoteStream(null);
     setActive(false);
+    setError(null);
   }, [remoteStream]);
 
   const startCall = useCallback(async (video: boolean) => {
@@ -106,5 +111,5 @@ export default function useWebRTC(sendSignal: (msg: SignalMessage) => void) {
 
   useEffect(() => () => cleanup(), [cleanup]);
 
-  return { localStream, remoteStream, startCall, handleSignal, endCall, active, isVideo: videoRef.current };
+  return { localStream, remoteStream, startCall, handleSignal, endCall, active, isVideo: videoRef.current, error };
 }

--- a/frontend/src/pages/ChatPage.tsx
+++ b/frontend/src/pages/ChatPage.tsx
@@ -100,6 +100,7 @@ export default function ChatPage() {
     endCall,
     active,
     isVideo,
+    error: mediaError,
   } = useWebRTC((msg: SignalMessage) => {
     if (selectedChannelId) {
       sendSignalMutation({
@@ -662,6 +663,9 @@ export default function ChatPage() {
               onEnd={endCall}
               video={isVideo}
             />
+          )}
+          {mediaError && (
+            <p className="text-red-400 text-center text-xs mt-2">{mediaError}</p>
           )}
           {error && <p className="text-red-400 text-center text-sm mt-2">{error}</p>}
         </main>


### PR DESCRIPTION
## Summary
- show user-facing errors in call components when access to camera/microphone is denied
- surface the error message from the `useWebRTC` hook in `ChatBox` and `ChatPage`

## Testing
- `npm run lint`
- `npm run build`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ae48fb0608326843888a2a65a012f