### PR TITLE
Persist UI preferences on the server

### DIFF
--- a/backend/accounts/migrations/0007_profile_preferences.py
+++ b/backend/accounts/migrations/0007_profile_preferences.py
@@ -1,0 +1,14 @@
+from django.db import migrations, models
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ('accounts', '0006_remove_profile_is_public'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='profile',
+            name='preferences',
+            field=models.JSONField(default=dict, blank=True),
+        ),
+    ]

--- a/backend/accounts/models.py
+++ b/backend/accounts/models.py
@@ -31,6 +31,7 @@ class Profile(models.Model):
     )
     avatar_url = models.URLField(blank=True)
     bio        = models.TextField(blank=True)
+    preferences = models.JSONField(default=dict, blank=True)
 
     def __str__(self):
         return f"Profile for {self.user.username}"

--- a/backend/accounts/schema.py
+++ b/backend/accounts/schema.py
@@ -9,6 +9,7 @@ from graphene_django.types import DjangoObjectType
 from graphql_jwt.shortcuts import get_token
 
 from .models import Profile, Invite, Friendship, Group, GroupMember
+from graphene.types.generic import GenericScalar
 from files.models import File
 
 User = get_user_model()
@@ -17,10 +18,11 @@ User = get_user_model()
 
 class ProfileType(DjangoObjectType):
     avatar_url = graphene.String()
+    preferences = GenericScalar()
 
     class Meta:
         model = Profile
-        fields = ("avatar_url", "bio")
+        fields = ("avatar_url", "bio", "preferences")
 
     def resolve_avatar_url(self, info):
         if self.avatar_file:
@@ -302,8 +304,9 @@ class UpdateProfile(graphene.Mutation):
         avatar_url = graphene.String()
         avatar_file_id = graphene.ID()
         bio = graphene.String()
+        preferences = GenericScalar()
 
-    def mutate(self, info, avatar_url=None, avatar_file_id=None, bio=None):
+    def mutate(self, info, avatar_url=None, avatar_file_id=None, bio=None, preferences=None):
         user = info.context.user
         if user.is_anonymous:
             raise GraphQLError("Login required.")
@@ -319,6 +322,8 @@ class UpdateProfile(graphene.Mutation):
             profile.avatar_url = info.context.build_absolute_uri(file_obj.upload.url)
         if bio is not None:
             profile.bio = bio
+        if preferences is not None:
+            profile.preferences = preferences
         profile.save()
         return UpdateProfile(profile=profile)
 

--- a/backend/accounts/tests.py
+++ b/backend/accounts/tests.py
@@ -67,3 +67,14 @@ class UpdateProfileTests(TestCase):
 
         self.user.profile.refresh_from_db()
         self.assertEqual(self.user.profile.avatar_file_id, file.id)
+
+    def test_update_profile_preferences(self):
+        from .schema import UpdateProfile
+
+        UpdateProfile().mutate(
+            self._info(),
+            preferences={"sidebar": True}
+        )
+
+        self.user.profile.refresh_from_db()
+        self.assertEqual(self.user.profile.preferences, {"sidebar": True})

--- a/frontend/src/auth/AuthContext.tsx
+++ b/frontend/src/auth/AuthContext.tsx
@@ -10,6 +10,7 @@ interface User {
   email: string;
   profile?: {
     avatarUrl?: string;
+    preferences?: Record<string, unknown>;
   };
 }
 

--- a/frontend/src/graphql/operations.ts
+++ b/frontend/src/graphql/operations.ts
@@ -50,6 +50,7 @@ export const QUERY_ME = gql`
       email
       profile {
         avatarUrl
+        preferences
       }
     }
   }
@@ -252,6 +253,17 @@ export const MUTATION_UPDATE_PROFILE = gql`
     updateProfile(avatarUrl: $avatarUrl, avatarFileId: $avatarFileId) {
       profile {
         avatarUrl
+      }
+    }
+  }
+`;
+
+// 13) Update UI preferences stored on the profile
+export const MUTATION_UPDATE_PREFERENCES = gql`
+  mutation UpdatePreferences($preferences: GenericScalar!) {
+    updateProfile(preferences: $preferences) {
+      profile {
+        preferences
       }
     }
   }

--- a/frontend/src/hooks/usePersistentState.ts
+++ b/frontend/src/hooks/usePersistentState.ts
@@ -1,0 +1,40 @@
+import { useState, useEffect } from 'react';
+import { useAuth } from '../auth/AuthContext';
+import { useMutation } from '@apollo/client';
+import { MUTATION_UPDATE_PREFERENCES } from '../graphql/operations';
+
+export default function usePersistentState<T>(key: string, defaultValue: T) {
+  const { user } = useAuth();
+  const [updatePrefs] = useMutation(MUTATION_UPDATE_PREFERENCES);
+  const [state, setState] = useState<T>(() => {
+    if (user?.profile?.preferences && key in user.profile.preferences) {
+      return user.profile.preferences[key] as T;
+    }
+    try {
+      const stored = localStorage.getItem(key);
+      return stored ? (JSON.parse(stored) as T) : defaultValue;
+    } catch {
+      return defaultValue;
+    }
+  });
+
+  useEffect(() => {
+    if (user?.profile?.preferences && key in user.profile.preferences) {
+      setState(user.profile.preferences[key] as T);
+    }
+  }, [user]);
+
+  useEffect(() => {
+    try {
+      localStorage.setItem(key, JSON.stringify(state));
+    } catch {
+      /* ignore */
+    }
+    if (user) {
+      const prefs = { ...(user.profile?.preferences || {}), [key]: state };
+      updatePrefs({ variables: { preferences: prefs } }).catch(() => {});
+    }
+  }, [key, state, user, updatePrefs]);
+
+  return [state, setState] as const;
+}

--- a/frontend/src/pages/ChatPage.tsx
+++ b/frontend/src/pages/ChatPage.tsx
@@ -20,6 +20,7 @@ import {
   SUBSCRIPTION_NODE_UPDATES,
 } from "../graphql/operations";
 import { useAuth } from "../auth/AuthContext";
+import usePersistentState from "../hooks/usePersistentState";
 import { useSearchParams, useNavigate } from "react-router-dom";
 import Header from "../components/Header";
 import {
@@ -68,7 +69,10 @@ export default function ChatPage() {
   const navigate = useNavigate();
 
   // panel open state
-  const [panelOpen, setPanelOpen] = useState(true);
+  const [panelOpen, setPanelOpen] = usePersistentState<boolean>(
+    "chat-panel-open",
+    true
+  );
 
   // chat UI state
   const [selectedFriendId, setSelectedFriendId] = useState<string | null>(null);

--- a/frontend/src/pages/MapPage.tsx
+++ b/frontend/src/pages/MapPage.tsx
@@ -63,6 +63,7 @@ import {
 import "reactflow/dist/style.css";
 import Header from "../components/Header";
 import ChatBox from "../components/ChatBox"; // your reusable chat overlay
+import usePersistentState from "../hooks/usePersistentState";
 
 interface FileOnNode {
   note: string;
@@ -101,7 +102,10 @@ interface Friend { id: string; username: string }
 interface Group { id: string; name: string }
 
 export default function MapPage() {
-  const [sidebarCollapsed, setSidebarCollapsed] = useState(false);
+  const [sidebarCollapsed, setSidebarCollapsed] = usePersistentState<boolean>(
+    "sidebar-collapsed",
+    false
+  );
 
   // set page title
   useEffect(() => {
@@ -459,9 +463,16 @@ export default function MapPage() {
 
   // custom node
   function CustomNode({ id, data, selected }: NodeProps<{
-    id:string; name:string; description:string; files:string[]; shares:NodeShare[]
+    id: string;
+    name: string;
+    description: string;
+    files: string[];
+    shares: NodeShare[];
   }>) {
-    const [collapsed, setCollapsed] = useState(false);
+    const [collapsed, setCollapsed] = usePersistentState<boolean>(
+      `node-collapsed-${id}`,
+      false
+    );
     const [nm, setNm] = useState(data.name);
     const [desc, setDesc] = useState(data.description);
     const [dropping, setDropping] = useState(false);

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -17,6 +17,7 @@ interface MeResult {
     email: string;
     profile: {
       avatarUrl: string | null;
+      preferences?: Record<string, unknown>;
     };
   };
 }


### PR DESCRIPTION
## Summary
- add `preferences` JSON field to `Profile`
- expose and update preferences via GraphQL
- sync UI state to server in `usePersistentState`
- fetch preferences in auth & settings pages

## Testing
- `python backend/manage.py test` *(fails: ModuleNotFoundError)*
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684af6d4ce308326acb197e2076a480c