### PR TITLE
Add export/import and image capture for map

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -14,6 +14,7 @@
         "apollo-upload-client": "^18.0.1",
         "graphql": "^16.11.0",
         "graphql-ws": "^6.0.5",
+        "html-to-image": "^1.11.13",
         "lucide-react": "^0.513.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
@@ -3853,6 +3854,12 @@
       "dependencies": {
         "react-is": "^16.7.0"
       }
+    },
+    "node_modules/html-to-image": {
+      "version": "1.11.13",
+      "resolved": "https://registry.npmjs.org/html-to-image/-/html-to-image-1.11.13.tgz",
+      "integrity": "sha512-cuOPoI7WApyhBElTTb9oqsawRvZ0rHhaHwghRLlTuffoD1B2aDemlCruLeZrUIIdvG7gs9xeELEPm6PhuASqrg==",
+      "license": "MIT"
     },
     "node_modules/ignore": {
       "version": "5.3.2",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -21,7 +21,8 @@
     "react-dom": "^18.2.0",
     "react-flow-renderer": "^10.3.17",
     "react-router-dom": "^6.30.1",
-    "reactflow": "^11.11.4"
+    "reactflow": "^11.11.4",
+    "html-to-image": "^1.11.13"
   },
   "devDependencies": {
     "@eslint/js": "^9.25.0",

--- a/frontend/src/pages/MapPage.tsx
+++ b/frontend/src/pages/MapPage.tsx
@@ -15,6 +15,7 @@ import ReactFlow, {
   addEdge,
   useNodesState,
   useEdgesState,
+  useReactFlow,
   Handle,
   type NodeDragHandler,
   type NodeProps,
@@ -59,7 +60,10 @@ import {
   Eye,
   Pen,
   MessageCircle,
+  Upload,
+  Camera,
 } from "lucide-react";
+import { toPng } from "html-to-image";
 import "reactflow/dist/style.css";
 import Header from "../components/Header";
 import ChatBox from "../components/ChatBox"; // your reusable chat overlay
@@ -386,6 +390,9 @@ export default function MapPage() {
   // ReactFlow state
   const [nodes, setNodes, onNodesChange] = useNodesState(graphNodes);
   const [edges, setEdges, onEdgesChange] = useEdgesState(graphEdges);
+  const rf = useReactFlow();
+  const flowRef = useRef<HTMLDivElement>(null);
+  const importRef = useRef<HTMLInputElement>(null);
   useEffect(() => {
     if (nodesData?.myNodes) {
       setNodes(graphNodes);
@@ -416,6 +423,52 @@ export default function MapPage() {
         onCompleted:()=>setEdges(eds=>eds.filter(x=>x.id!==e.id))
       })
     );
+  };
+
+  const exportJson = async () => {
+    const obj = rf.toObject();
+    const data = JSON.stringify({ nodes: obj.nodes, edges: obj.edges }, null, 2);
+    const blob = new Blob([data], { type: "application/json" });
+    const name = `map-export-${Date.now()}.json`;
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = name;
+    a.click();
+    URL.revokeObjectURL(url);
+    const file = new File([blob], name, { type: "application/json" });
+    uploadFile({ variables: { name, upload: file } }).catch(() => {});
+  };
+
+  const importJson = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    try {
+      const text = await file.text();
+      const obj = JSON.parse(text);
+      if (obj.nodes && obj.edges) {
+        setNodes(obj.nodes);
+        setEdges(obj.edges);
+        obj.nodes.forEach((n: Node) =>
+          savePosition(n.id, n.position.x, n.position.y)
+        );
+      }
+    } catch {
+      alert("Invalid file");
+    }
+  };
+
+  const exportImage = async () => {
+    if (!flowRef.current) return;
+    const dataUrl = await toPng(flowRef.current);
+    const name = `map-image-${Date.now()}.png`;
+    const link = document.createElement("a");
+    link.href = dataUrl;
+    link.download = name;
+    link.click();
+    const blob = await (await fetch(dataUrl)).blob();
+    const file = new File([blob], name, { type: "image/png" });
+    uploadFile({ variables: { name, upload: file } }).catch(() => {});
   };
   const handleConnect = useCallback((c:Connection)=>{
     const temp = `t-${c.source}-${c.target}-${Date.now()}` as const;
@@ -779,7 +832,32 @@ export default function MapPage() {
         >
           <Minus size={16} className="text-white" />
         </button>
+        <button
+          onClick={exportJson}
+          className="p-2 bg-orange-500 hover:bg-red-600 rounded"
+        >
+          <Download size={16} className="text-white" />
+        </button>
+        <button
+          onClick={() => importRef.current?.click()}
+          className="p-2 bg-orange-500 hover:bg-red-600 rounded"
+        >
+          <Upload size={16} className="text-white" />
+        </button>
+        <button
+          onClick={exportImage}
+          className="p-2 bg-orange-500 hover:bg-red-600 rounded"
+        >
+          <Camera size={16} className="text-white" />
+        </button>
       </Header>
+      <input
+        type="file"
+        accept="application/json"
+        ref={importRef}
+        onChange={importJson}
+        className="hidden"
+      />
 
       {/* MAIN */}
       <div className="flex flex-1 flex-col sm:flex-row">
@@ -994,7 +1072,11 @@ export default function MapPage() {
         </aside>
 
         {/* CANVAS */}
-        <div className="flex-1 relative overscroll-none" style={{ touchAction:'none', background:'#2D2D2D' }}>
+        <div
+          className="flex-1 relative overscroll-none"
+          style={{ touchAction: 'none', background: '#2D2D2D' }}
+          ref={flowRef}
+        >
           <ReactFlowProvider>
             <ReactFlow
               nodes={nodes}


### PR DESCRIPTION
## Summary
- add html-to-image dependency
- support exporting, importing, and screenshotting diagrams
- upload exported files and screenshots to storage

## Testing
- `npm run lint`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684afe9daee483269c07939f4cf3f4c3