### PR TITLE
Fix missing dependencies when starting Docker

### DIFF
--- a/start-vault.ps1
+++ b/start-vault.ps1
@@ -46,5 +46,7 @@ Write-Host "GraphQL WebSocket endpoint:"
 Write-Host "  ws://${ip}:8000/graphql/"
 Write-Host ""
 
-# 4. Launch Docker Compose
-docker compose up --build
+# 4. Build images without cache to ensure dependencies are installed
+docker compose build --no-cache
+# 5. Launch Docker Compose
+docker compose up


### PR DESCRIPTION
## Summary
- rebuild Docker images without cache in `start-vault.ps1`

This ensures new frontend dependencies like `html-to-image` are installed whenever the containers are started.

## Testing
- `npm ci`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_684b01642c2483268b1e8197a097dc10