### PR TITLE
Automate frontend dependency setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,13 +244,13 @@ Compose so the containers pick up the new settings.
 
 ### Frontend
 
-1. **Install Node dependencies**:
-   \`\`\`bash
-   cd ../frontend
-   npm install
-   \`\`\`
+```bash
+cd ../frontend
+# dependencies are installed automatically on first dev run
+```
 
-2. **Set environment variable** (point Apollo to your local Django):
+
+1. **Set environment variable** (point Apollo to your local Django):
    \`\`\`bash
    export VITE_GRAPHQL_URL=http://127.0.0.1:8000/graphql/
    export VITE_GRAPHQL_WS_URL=ws://127.0.0.1:8000/graphql/
@@ -261,13 +261,13 @@ Compose so the containers pick up the new settings.
    # $env:CHOKIDAR_USEPOLLING="true"
    \`\`\`
 
-3. **Start development server**:
+2. **Start development server** (installs dependencies on first run):
    \`\`\`bash
    npm run dev
    \`\`\`
    The frontend will be available at \`http://localhost:5173/\`.
 
-4. **Build for production & copy files**:
+3. **Build for production & copy files**:
    ```bash
    npm run build
    cp dist/index.html ../backend/templates/index.html
@@ -289,7 +289,6 @@ Compose so the containers pick up the new settings.
 
 ### Frontend (inside \`frontend/\`)
 
-- \`npm install\`  
 - \`npm run dev\` – Start Vite dev server on \`:5173\`  
 - \`npm run build\` – Produce a production build (output in \`dist/\`)  
 - \`npm run preview\` – Preview the production build on a local static server  

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -4,6 +4,7 @@
   "version": "0.0.0",
   "type": "module",
   "scripts": {
+    "predev": "node scripts/ensureDeps.cjs",
     "dev": "vite",
     "build": "tsc -b && vite build",
     "lint": "eslint .",

--- a/frontend/scripts/ensureDeps.cjs
+++ b/frontend/scripts/ensureDeps.cjs
@@ -1,0 +1,11 @@
+const fs = require('fs');
+const path = require('path');
+const { execSync } = require('child_process');
+
+const projectRoot = path.join(__dirname, '..');
+const modulesPath = path.join(projectRoot, 'node_modules');
+
+if (!fs.existsSync(modulesPath)) {
+  console.log('node_modules not found. Installing dependencies...');
+  execSync('npm install', { stdio: 'inherit', cwd: projectRoot });
+}


### PR DESCRIPTION
## Summary
- ensure `npm install` runs automatically before `npm run dev`
- document automatic dependency install in README

## Testing
- `node scripts/ensureDeps.cjs` (installs modules)
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_684b06b6dee88326bac207be1562a83b