### PR TITLE
Improve chat bubbles and remove avatar UI

### DIFF
--- a/frontend/src/components/ChatBox.tsx
+++ b/frontend/src/components/ChatBox.tsx
@@ -145,7 +145,7 @@ export default function ChatBox({ channelId, onClose, title }: ChatBoxProps) {
                 className={`flex ${mine ? "justify-end" : "justify-start"}`}
               >
                 <div
-                  className={`max-w-[75%] px-3 py-2 rounded-2xl text-sm ${
+                  className={`max-w-[75%] px-3 py-2 rounded-2xl text-sm break-words whitespace-pre-wrap ${
                     mine ? "bg-orange-500 text-white" : "bg-neutral-700 text-gray-100"
                   }`}
                 >

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -18,21 +18,7 @@ export default function Header({ children }: HeaderProps) {
         {children}
         <Menu as="div" className="relative">
           <Menu.Button className="flex items-center space-x-2 focus:outline-none">
-            {user?.profile?.avatarUrl ? (
-              <img
-                src={user.profile.avatarUrl}
-                alt="Avatar"
-                className="h-8 w-8 rounded-full object-cover"
-                onError={(e) => {
-                  (e.target as HTMLImageElement).style.display = "none";
-                  (e.target as HTMLImageElement).closest("div")?.classList.remove("hidden");
-                }}
-              />
-            ) : (
-              <div className="h-8 w-8 rounded-full bg-neutral-700 flex items-center justify-center text-gray-300">
-                <User size={16} />
-              </div>
-            )}
+            <User size={16} className="text-gray-300" />
             <span className="text-gray-200">{user?.username}</span>
             <ChevronDown className="text-gray-400" size={16} />
           </Menu.Button>

--- a/frontend/src/pages/ChatPage.tsx
+++ b/frontend/src/pages/ChatPage.tsx
@@ -14,6 +14,7 @@ import {
   MUTATION_JOIN_GROUP_CHANNEL,
   MUTATION_JOIN_NODE_CHANNEL,
   MUTATION_SEND_MESSAGE,
+  MUTATION_MARK_CHANNEL_READ,
   MUTATION_CREATE_FRIEND_INVITE,
   MUTATION_REDEEM_FRIEND_INVITE,
   MUTATION_CREATE_GROUP,
@@ -191,6 +192,8 @@ export default function ChatPage() {
     onError: () => setError("Failed to send. Please try again."),
   });
 
+  const [markRead] = useMutation(MUTATION_MARK_CHANNEL_READ);
+
   const [createFriendInvite] = useMutation(MUTATION_CREATE_FRIEND_INVITE, {
     onCompleted: res => setInviteCode(res.createFriendInvite.invite.code),
   });
@@ -258,6 +261,13 @@ export default function ChatPage() {
     () => { messagesEndRef.current?.scrollIntoView({ behavior:"smooth" }) },
     [messagesData?.channelMessages]
   );
+
+  useEffect(() => {
+    if (selectedChannelId && messagesData?.channelMessages) {
+      markRead({ variables: { channelId: selectedChannelId } })
+        .then(() => refetchChannels());
+    }
+  }, [selectedChannelId, messagesData?.channelMessages, markRead, refetchChannels]);
 
 
   function selectFriend(id:string){
@@ -614,7 +624,7 @@ export default function ChatPage() {
                       className={`flex ${mine ? "justify-end" : "justify-start"}`}
                     >
                       <div
-                        className={`max-w-[75%] px-3 py-2 rounded-2xl text-sm ${
+                        className={`max-w-[75%] px-3 py-2 rounded-2xl text-sm break-words whitespace-pre-wrap ${
                           mine ? "bg-neutral-700" : "bg-neutral-600"
                         }`}
                       >


### PR DESCRIPTION
## Summary
- strip avatar logic from Header and Settings page
- prevent chat bubbles from overflowing horizontally
- mark channel messages as read when opened

## Testing
- `npm run lint`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684b3d49ac24832699005fd274d33ff0