### PR TITLE
Remove unread message handling

### DIFF
--- a/frontend/src/components/ChatBox.tsx
+++ b/frontend/src/components/ChatBox.tsx
@@ -6,7 +6,6 @@ import { useQuery, useMutation, useSubscription } from "@apollo/client";
 import {
   QUERY_CHANNEL_MESSAGES,
   MUTATION_SEND_MESSAGE,
-  MUTATION_MARK_CHANNEL_READ,
   SUBSCRIPTION_MESSAGE_UPDATES,
 } from "../graphql/operations";
 import { Send, X } from "lucide-react";
@@ -60,13 +59,8 @@ export default function ChatBox({ channelId, onClose, title }: ChatBoxProps) {
     },
   });
 
-  const [markRead] = useMutation(MUTATION_MARK_CHANNEL_READ);
-
   useEffect(() => {
     messagesEndRef.current?.scrollIntoView({ behavior: "smooth" });
-    if (channelId && data?.channelMessages) {
-      markRead({ variables: { channelId } });
-    }
   }, [data?.channelMessages]);
 
   // Scroll to bottom on new messages
@@ -81,11 +75,6 @@ export default function ChatBox({ channelId, onClose, title }: ChatBoxProps) {
     });
   };
 
-  useEffect(() => {
-    if (channelId) {
-      markRead({ variables: { channelId } });
-    }
-  }, [channelId]);
 
   const onKeyDown: React.KeyboardEventHandler<HTMLTextAreaElement> = (e) => {
     if (e.key === "Enter" && !e.shiftKey) {

--- a/frontend/src/graphql/operations.ts
+++ b/frontend/src/graphql/operations.ts
@@ -547,7 +547,6 @@ export const QUERY_MY_CHANNELS = gql`
       id
       name
       channelType
-      unreadCount
       node {
         id
         name
@@ -670,15 +669,6 @@ export const MUTATION_SEND_MESSAGE = gql`
         }
         createdAt
       }
-    }
-  }
-`;
-
-// 7) Mark all messages in a channel as read
-export const MUTATION_MARK_CHANNEL_READ = gql`
-  mutation MarkChannelRead($channelId: ID!) {
-    markChannelRead(channelId: $channelId) {
-      ok
     }
   }
 `;


### PR DESCRIPTION
## Summary
- drop unread_count and markChannelRead from backend schema
- clean up frontend to stop querying unread counts and remove mark-as-read calls

## Testing
- `python backend/manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_684b4006f64c8326ac4e8bc2f2b8b6de