### PR TITLE
Add group deletion button in chat

### DIFF
--- a/frontend/src/graphql/operations.ts
+++ b/frontend/src/graphql/operations.ts
@@ -247,6 +247,15 @@ export const MUTATION_JOIN_GROUP_BY_INVITE = gql`
   }
 `;
 
+// 12) Delete a group you own
+export const MUTATION_DELETE_GROUP = gql`
+  mutation DeleteGroup($groupId: ID!) {
+    deleteGroup(groupId: $groupId) {
+      ok
+    }
+  }
+`;
+
 // 12) Update the authenticated user's profile
 export const MUTATION_UPDATE_PROFILE = gql`
   mutation UpdateProfile($avatarUrl: String, $avatarFileId: ID) {


### PR DESCRIPTION
## Summary
- add `MUTATION_DELETE_GROUP` in GraphQL operations
- allow ChatPage to delete groups owned by the user

## Testing
- `npm run build`
- `DJANGO_SETTINGS_MODULE=test_settings python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_684b4589582c832686407bc5e661e331