### PR TITLE
Add friend and group management

### DIFF
--- a/backend/accounts/tests.py
+++ b/backend/accounts/tests.py
@@ -1,3 +1,54 @@
 from django.test import TestCase
+from django.contrib.auth import get_user_model
+from types import SimpleNamespace
+from graphene.test import Client
 
-# Create your tests here.
+from vault.schema import schema
+from .models import Friendship, Group, GroupMember
+
+User = get_user_model()
+
+class AccountsMutationTests(TestCase):
+    def setUp(self):
+        self.client = Client(schema)
+        self.u1 = User.objects.create_user(username="alice", password="x")
+        self.u2 = User.objects.create_user(username="bob", password="x")
+
+    def test_unfriend(self):
+        Friendship.objects.create(user=self.u1, friend=self.u2)
+        Friendship.objects.create(user=self.u2, friend=self.u1)
+        q = """
+            mutation($id: ID!){
+              unfriend(friendId:$id){ ok }
+            }
+        """
+        self.client.execute(q, variables={"id": str(self.u2.id)}, context_value=SimpleNamespace(user=self.u1))
+        self.assertFalse(Friendship.objects.exists())
+
+    def test_leave_group(self):
+        g = Group.objects.create(name="g1", owner=self.u1)
+        GroupMember.objects.create(user=self.u1, group=g)
+        GroupMember.objects.create(user=self.u2, group=g)
+        q = """
+            mutation($gid: ID!){
+              leaveGroup(groupId:$gid){ ok }
+            }
+        """
+        self.client.execute(q, variables={"gid": str(g.id)}, context_value=SimpleNamespace(user=self.u2))
+        self.assertFalse(GroupMember.objects.filter(user=self.u2, group=g).exists())
+
+    def test_remove_group_member(self):
+        g = Group.objects.create(name="g1", owner=self.u1)
+        GroupMember.objects.create(user=self.u1, group=g)
+        GroupMember.objects.create(user=self.u2, group=g)
+        q = """
+            mutation($gid: ID!, $uid: ID!){
+              removeGroupMember(groupId:$gid, userId:$uid){ ok }
+            }
+        """
+        self.client.execute(
+            q,
+            variables={"gid": str(g.id), "uid": str(self.u2.id)},
+            context_value=SimpleNamespace(user=self.u1),
+        )
+        self.assertFalse(GroupMember.objects.filter(user=self.u2, group=g).exists())

--- a/backend/vault/test_settings.py
+++ b/backend/vault/test_settings.py
@@ -1,0 +1,8 @@
+from .settings import *
+
+DATABASES = {
+    'default': {
+        'ENGINE': 'django.db.backends.sqlite3',
+        'NAME': ':memory:',
+    }
+}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -9,6 +9,7 @@ import DashboardPage from "./pages/DashboardPage";
 import StoragePage from "./pages/StoragePage";
 import MapPage from "./pages/MapPage";
 import ChatPage from "./pages/ChatPage";             // ← import this
+import GroupMembersPage from "./pages/GroupMembersPage";
 import SettingsPage from "./pages/SettingsPage";
 import NotFoundPage from "./pages/NotFoundPage";
 
@@ -53,6 +54,14 @@ export default function App() {
           element={
             <ProtectedRoute>
               <ChatPage />
+            </ProtectedRoute>
+          }
+        />
+        <Route
+          path="/groups/:groupId"
+          element={
+            <ProtectedRoute>
+              <GroupMembersPage />
             </ProtectedRoute>
           }
         />

--- a/frontend/src/graphql/operations.ts
+++ b/frontend/src/graphql/operations.ts
@@ -226,6 +226,33 @@ export const MUTATION_JOIN_GROUP_BY_INVITE = gql`
   }
 `;
 
+// 12) Unfriend a user
+export const MUTATION_UNFRIEND = gql`
+  mutation Unfriend($friendId: ID!) {
+    unfriend(friendId: $friendId) {
+      ok
+    }
+  }
+`;
+
+// 13) Leave a group
+export const MUTATION_LEAVE_GROUP = gql`
+  mutation LeaveGroup($groupId: ID!) {
+    leaveGroup(groupId: $groupId) {
+      ok
+    }
+  }
+`;
+
+// 14) Remove a member from a group (owner only)
+export const MUTATION_REMOVE_GROUP_MEMBER = gql`
+  mutation RemoveGroupMember($groupId: ID!, $userId: ID!) {
+    removeGroupMember(groupId: $groupId, userId: $userId) {
+      ok
+    }
+  }
+`;
+
 /* ──────────────────────────────────────────────────────────────────────────────
    FILES (UPLOADS / VERSIONS / SHARES)
    ────────────────────────────────────────────────────────────────────────────── */

--- a/frontend/src/pages/ChatPage.tsx
+++ b/frontend/src/pages/ChatPage.tsx
@@ -11,6 +11,7 @@ import {
   MUTATION_SEND_MESSAGE,
   MUTATION_CREATE_FRIEND_INVITE,
   MUTATION_REDEEM_FRIEND_INVITE,
+  MUTATION_UNFRIEND,
 } from "../graphql/operations";
 import { useAuth } from "../auth/AuthContext";
 import { useSearchParams, useNavigate } from "react-router-dom";
@@ -101,6 +102,10 @@ export default function ChatPage() {
         navigate("/chat", { replace: true });
       },
     });
+
+  const [unfriend] = useMutation(MUTATION_UNFRIEND, {
+    onCompleted: () => refetchFriends(),
+  });
 
   // URL auto‐redeem
   useEffect(() => {
@@ -209,17 +214,27 @@ export default function ChatPage() {
         <div className="flex-1 overflow-y-auto space-y-2">
           {friendsData!.friends.length ? (
             friendsData!.friends.map((f) => (
-              <button
+              <div
                 key={f.id}
-                onClick={() => selectFriend(f.id)}
-                className={`w-full text-left px-3 py-2 rounded-md focus:outline-none ${
-                  selectedFriendId === f.id
-                    ? "bg-red-600 text-white"
-                    : "bg-orange-500 text-white hover:bg-orange-600"
-                }`}
+                className="flex items-center space-x-2"
               >
-                {f.username}
-              </button>
+                <button
+                  onClick={() => selectFriend(f.id)}
+                  className={`flex-1 text-left px-3 py-2 rounded-md focus:outline-none ${
+                    selectedFriendId === f.id
+                      ? "bg-red-600 text-white"
+                      : "bg-orange-500 text-white hover:bg-orange-600"
+                  }`}
+                >
+                  {f.username}
+                </button>
+                <button
+                  onClick={() => unfriend({ variables: { friendId: f.id } })}
+                  className="px-2 py-2 bg-neutral-700 hover:bg-neutral-600 rounded-md"
+                >
+                  <X size={16} />
+                </button>
+              </div>
             ))
           ) : (
             <p className="text-gray-400 text-sm">No friends available.</p>

--- a/frontend/src/pages/GroupMembersPage.tsx
+++ b/frontend/src/pages/GroupMembersPage.tsx
@@ -1,0 +1,114 @@
+// src/pages/GroupMembersPage.tsx
+"use client";
+
+import { useEffect } from "react";
+import { useParams, useNavigate } from "react-router-dom";
+import { useQuery, useMutation } from "@apollo/client";
+import {
+  QUERY_GROUP_MEMBERS,
+  QUERY_MY_GROUPS,
+  MUTATION_REMOVE_GROUP_MEMBER,
+  MUTATION_LEAVE_GROUP,
+} from "../graphql/operations";
+import { useAuth } from "../auth/AuthContext";
+
+interface Member {
+  id: string;
+  username: string;
+}
+interface Group {
+  id: string;
+  owner: { id: string };
+}
+
+export default function GroupMembersPage() {
+  const { groupId } = useParams<{ groupId: string }>();
+  const { user, logout } = useAuth();
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    document.title = "Group Members";
+  }, []);
+
+  const { data, loading, error, refetch } = useQuery<{ groupMembers: Member[] }>(
+    QUERY_GROUP_MEMBERS,
+    { variables: { groupId: groupId || "" }, skip: !groupId }
+  );
+
+  const { data: myGroups } = useQuery<{ myGroups: Group[] }>(QUERY_MY_GROUPS, {
+    variables: { limit: 50, offset: 0 },
+  });
+
+  const group = myGroups?.myGroups.find((g) => g.id === groupId);
+  const isOwner = group?.owner.id === user?.id;
+
+  const [removeMember] = useMutation(MUTATION_REMOVE_GROUP_MEMBER, {
+    onCompleted: () => refetch(),
+  });
+
+  const [leaveGroup] = useMutation(MUTATION_LEAVE_GROUP, {
+    onCompleted: () => navigate("/dashboard"),
+  });
+
+  if (loading) return <div className="p-6 text-white">Loading…</div>;
+  if (error) return <div className="p-6 text-red-500">Error loading group.</div>;
+
+  const members = data?.groupMembers || [];
+
+  return (
+    <div className="flex flex-col h-screen bg-neutral-900 text-white">
+      <header className="flex items-center justify-between px-6 py-4 bg-neutral-800/75 backdrop-blur-sm">
+        <h1 className="text-2xl font-extrabold">
+          <span className="text-red-500">V</span>ault
+        </h1>
+        <div className="flex items-center space-x-4">
+          <span>{user?.username}</span>
+          <button
+            onClick={() => {
+              logout();
+              navigate("/login");
+            }}
+            className="px-4 py-2 bg-orange-500 rounded-md"
+          >
+            Logout
+          </button>
+        </div>
+      </header>
+      <main className="flex-1 p-6 space-y-4 overflow-auto">
+        <h2 className="text-2xl font-semibold mb-4">Group Members</h2>
+        <ul className="space-y-2">
+          {members.map((m) => (
+            <li
+              key={m.id}
+              className="flex items-center justify-between bg-neutral-800 p-3 rounded"
+            >
+              <span>{m.username}</span>
+              <div className="space-x-2">
+                {isOwner && m.id !== user?.id && (
+                  <button
+                    onClick={() =>
+                      removeMember({ variables: { groupId, userId: m.id } })
+                    }
+                    className="px-2 py-1 text-sm bg-red-600 rounded"
+                  >
+                    Remove
+                  </button>
+                )}
+                {m.id === user?.id && (
+                  <button
+                    onClick={() =>
+                      leaveGroup({ variables: { groupId } })
+                    }
+                    className="px-2 py-1 text-sm bg-red-600 rounded"
+                  >
+                    Leave Group
+                  </button>
+                )}
+              </div>
+            </li>
+          ))}
+        </ul>
+      </main>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add `Unfriend`, `LeaveGroup`, and `RemoveGroupMember` mutations
- expose new mutations in Accounts schema
- extend frontend GraphQL operations for new mutations
- show unfriend button in chat page
- add new page to list group members with remove/leave actions
- add SQLite test settings and mutation tests

## Testing
- `pip install -r backend/requirements.txt`
- `DJANGO_SETTINGS_MODULE=vault.test_settings python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_684b49149e288326b58dfd79f9a9d4c8