### PR TITLE
Add UI for viewing and uploading file versions

### DIFF
--- a/frontend/src/components/FileVersionsDropdown.tsx
+++ b/frontend/src/components/FileVersionsDropdown.tsx
@@ -1,0 +1,79 @@
+import { useState } from "react";
+import { useLazyQuery } from "@apollo/client";
+import { QUERY_FILE_VERSIONS } from "../graphql/operations";
+import { ChevronDown, ChevronRight, Download } from "lucide-react";
+
+interface Props {
+  fileId: string;
+}
+
+interface Version {
+  id: string;
+  uploadUrl: string;
+  note: string | null;
+  createdAt: string;
+}
+
+interface QueryResult {
+  fileVersions: Version[];
+}
+
+export default function FileVersionsDropdown({ fileId }: Props) {
+  const [open, setOpen] = useState(false);
+  const [fetchVersions, { data, loading, called }] = useLazyQuery<QueryResult>(
+    QUERY_FILE_VERSIONS,
+    { variables: { fileId } }
+  );
+
+  const toggle = () => {
+    if (!open && !called) {
+      fetchVersions();
+    }
+    setOpen((o) => !o);
+  };
+
+  const versions = data?.fileVersions || [];
+
+  return (
+    <div className="mt-1">
+      <button
+        onClick={toggle}
+        className="flex items-center text-sm text-orange-300 focus:outline-none"
+      >
+        {open ? (
+          <ChevronDown size={14} className="text-orange-300" />
+        ) : (
+          <ChevronRight size={14} className="text-orange-300" />
+        )}
+        <span className="ml-1">Versions</span>
+      </button>
+      {open && (
+        <ul className="mt-1 space-y-1 pl-4">
+          {loading ? (
+            <li className="text-gray-400 text-sm">Loading…</li>
+          ) : versions.length === 0 ? (
+            <li className="text-gray-400 text-sm">No versions</li>
+          ) : (
+            versions.map((v) => (
+              <li
+                key={v.id}
+                className="flex items-center justify-between bg-neutral-700 px-2 py-1 rounded text-sm"
+              >
+                <span className="truncate">
+                  {new Date(v.createdAt).toLocaleString()}
+                </span>
+                <a
+                  href={v.uploadUrl}
+                  download
+                  className="p-1 bg-neutral-800 hover:bg-red-600 rounded"
+                >
+                  <Download size={12} className="text-white" />
+                </a>
+              </li>
+            ))
+          )}
+        </ul>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- allow uploading as a new file or as a version in **StoragePage** and **MapPage**
- show dropdown of file versions for files in both pages
- extract FileVersionsDropdown component for re-use

## Testing
- `npm run build`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684d58725e788326adca98743dc67a0c