### PR TITLE
Add file name display for version list

### DIFF
--- a/backend/files/schema.py
+++ b/backend/files/schema.py
@@ -1,5 +1,6 @@
 # files/schema.py
 
+import os
 import graphene
 from graphql import GraphQLError
 from graphene_django import DjangoObjectType
@@ -13,9 +14,14 @@ from accounts.schema import UserType
 # ── Types ────────────────────────────────────────────────────────────────────
 
 class VersionType(DjangoObjectType):
+    file_name = graphene.String()
+
     class Meta:
         model = Version
         fields = ("id", "upload", "note", "created_at")
+
+    def resolve_file_name(self, info):
+        return os.path.basename(self.upload.name)
 
 
 class FileShareType(DjangoObjectType):

--- a/frontend/src/components/FileVersionsDropdown.tsx
+++ b/frontend/src/components/FileVersionsDropdown.tsx
@@ -11,6 +11,7 @@ interface Version {
   id: string;
   uploadUrl: string;
   note: string | null;
+  fileName: string;
   createdAt: string;
 }
 
@@ -61,7 +62,7 @@ export default function FileVersionsDropdown({ fileId }: Props) {
               >
                 <div className="flex-1 min-w-0">
                   <p className="text-sm font-medium truncate">
-                    {v.note?.trim() || "Untitled version"}
+                    {v.note?.trim() || v.fileName || "Untitled version"}
                   </p>
                   <p className="text-xs text-gray-400">
                     {new Date(v.createdAt).toLocaleString()}

--- a/frontend/src/graphql/operations.ts
+++ b/frontend/src/graphql/operations.ts
@@ -359,6 +359,7 @@ export const QUERY_FILE_VERSIONS = gql`
       id
       uploadUrl: upload
       note
+      fileName
       createdAt
     }
   }
@@ -389,6 +390,7 @@ export const MUTATION_UPLOAD_FILE = gql`
         id
         uploadUrl: upload
         note
+        fileName
         createdAt
       }
     }
@@ -403,6 +405,7 @@ export const MUTATION_ADD_FILE_VERSION = gql`
         id
         uploadUrl: upload
         note
+        fileName
         createdAt
       }
     }

--- a/frontend/src/pages/StoragePage.tsx
+++ b/frontend/src/pages/StoragePage.tsx
@@ -35,6 +35,7 @@ interface UploadFileResult {
       id: string;
       uploadUrl: string;
       note: string | null;
+      fileName: string;
       createdAt: string;
     };
   };


### PR DESCRIPTION
## Summary
- expose `file_name` field for file versions in GraphQL
- show uploaded filename in version dropdown
- request `fileName` from GraphQL operations
- type updates for returned data

## Testing
- `python backend/manage.py test backend --settings=test_settings -v0`

------
https://chatgpt.com/codex/tasks/task_e_684d6a369ce883268c17df0c0511e98f