### PR TITLE
Improve reset script with volume cleanup

### DIFF
--- a/reset-vault.ps1
+++ b/reset-vault.ps1
@@ -1,19 +1,21 @@
 # reset-vault.ps1
 # ────────────────────────────────────────────────────────────────────
 
-# 1) Stop and remove containers (volumes stay intact)
-docker compose down
+# 1) Stop & remove containers **and** volumes
+Write-Host "Stopping all containers & removing associated volumes…" -ForegroundColor Cyan
+docker compose down --volumes
 
-# 2) Drop & recreate the vault_db schema
-docker compose run --rm vault_db `
-  mysql -uroot -prootpass `
-    -e "DROP DATABASE IF EXISTS vault_db; CREATE DATABASE vault_db;"
+# 2) (Optional) prune any dangling volumes
+# docker volume prune -f
 
-# 3) Remove all user-uploaded media
+# 3) Remove user-uploaded media from disk
 if (Test-Path "./backend/media") {
-  Write-Host "Deleting backend/media…" -ForegroundColor Yellow
-  Remove-Item -Recurse -Force "./backend/media/*"
+    Write-Host "Deleting backend/media…" -ForegroundColor Yellow
+    Remove-Item -Recurse -Force "./backend/media/*"
 }
 
-Write-Host "Reset complete. You can now run:" -ForegroundColor Green
-Write-Host "    .\\start-vault.ps1   # or docker compose up --build" -ForegroundColor Green
+Write-Host ""
+Write-Host " Vault database & media wiped clean." -ForegroundColor Green
+Write-Host "Now rebuild everything with:" -ForegroundColor Green
+Write-Host "    docker compose up --build" -ForegroundColor Green
+Write-Host "or run your start-vault.ps1 if you have one." -ForegroundColor Green


### PR DESCRIPTION
## Summary
- wipe docker volumes when resetting Vault
- provide friendly output messages

## Testing
- `python backend/manage.py test accounts files graph chat --settings=test_settings --verbosity=2`

------
https://chatgpt.com/codex/tasks/task_e_684f394614748326afe6053ff5307bce